### PR TITLE
feat: 인자로 받은 문자의 초성, 중성, 종성 위치 가능 여부를 파악하는 함수 추가 #24

### DIFF
--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -1,6 +1,6 @@
 import { HANGUL_CHARACTERS_BY_FIRST_INDEX } from './constants';
 import { disassembleHangulToGroups } from './disassemble';
-import { getFirstConsonants } from './utils';
+import { canBeChosung, getFirstConsonants } from './utils';
 
 export function chosungIncludes(x: string, y: string) {
   if (!isOnlyInitialConsonant(y)) {
@@ -18,6 +18,6 @@ export function chosungIncludes(x: string, y: string) {
  */
 function isOnlyInitialConsonant(str: string) {
   return disassembleHangulToGroups(str).every(disassembled => {
-    return disassembled.length === 1 && HANGUL_CHARACTERS_BY_FIRST_INDEX.includes(disassembled[0] ?? '');
+    return disassembled.length === 1 && canBeChosung(disassembled[0] ?? '');
   });
 }

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getFirstConsonants, hasBatchim } from './utils';
+import { canBeChosung, canBeJongsung, canBeJungsung, getFirstConsonants, hasBatchim } from './utils';
 
 describe('hasBatchim', () => {
   it('should return true for the character "값"', () => {
@@ -35,5 +35,68 @@ describe('getFirstConsonants', () => {
 
   it('should extract the initial consonants "ㄸㅇ ㅆㄱ" from the phrase "띄어 쓰기"', () => {
     expect(getFirstConsonants('띄어 쓰기')).toBe('ㄸㅇ ㅆㄱ');
+  });
+});
+
+describe('canBeChosung', () => {
+  it('ㄱ', () => {
+    expect(canBeChosung('ㄱ')).toBe(true);
+  });
+  it('ㅃ', () => {
+    expect(canBeChosung('ㅃ')).toBe(true);
+  });
+  it('ㅏ', () => {
+    expect(canBeChosung('ㅏ')).toBe(false);
+  });
+  it('ㅘ', () => {
+    expect(canBeChosung('ㅏ')).toBe(false);
+  });
+  it('ㄱㅅ', () => {
+    expect(canBeChosung('ㅏ')).toBe(false);
+  });
+  it('가', () => {
+    expect(canBeChosung('ㅏ')).toBe(false);
+  });
+});
+
+describe('canBeJungsung', () => {
+  it('ㅗㅏ', () => {
+    expect(canBeJungsung('ㅗㅏ')).toBe(true);
+  });
+  it('ㅏ', () => {
+    expect(canBeJungsung('ㅏ')).toBe(true);
+  });
+  it('ㄱ', () => {
+    expect(canBeJungsung('ㄱ')).toBe(false);
+  });
+  it('ㄱㅅ', () => {
+    expect(canBeJungsung('ㄱㅅ')).toBe(false);
+  });
+  it('가', () => {
+    expect(canBeJungsung('가')).toBe(false);
+  });
+});
+
+describe('canBeJongsung', () => {
+  it('ㄱ', () => {
+    expect(canBeJongsung('ㄱ')).toBe(true);
+  });
+  it('ㄱㅅ', () => {
+    expect(canBeJongsung('ㄱㅅ')).toBe(true);
+  });
+  it('ㅂㅅ', () => {
+    expect(canBeJongsung('ㅂㅅ')).toBe(true);
+  });
+  it('ㅎㄹ', () => {
+    expect(canBeJongsung('ㅎㄹ')).toBe(false);
+  });
+  it('ㅗㅏ', () => {
+    expect(canBeJongsung('ㅗㅏ')).toBe(false);
+  });
+  it('ㅏ', () => {
+    expect(canBeJongsung('ㅏ')).toBe(false);
+  });
+  it('가', () => {
+    expect(canBeJongsung('ㅏ')).toBe(false);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,8 @@
+import {
+  HANGUL_CHARACTERS_BY_FIRST_INDEX,
+  HANGUL_CHARACTERS_BY_LAST_INDEX,
+  HANGUL_CHARACTERS_BY_MIDDLE_INDEX,
+} from './constants';
 import { disassembleHangulToGroups } from './disassemble';
 import { disassembleCompleteHangulCharacter } from './disassembleCompleteHangulCharacter';
 
@@ -40,4 +45,69 @@ export function getFirstConsonants(word: string) {
   return disassembleHangulToGroups(word).reduce((firstConsonants, [consonant]) => {
     return `${firstConsonants}${consonant}`;
   }, '');
+}
+
+/**
+ * @name canBeChosung
+ * @description
+ * 인자로 받은 문자가 초성으로 위치할 수 있는 문자인지 검사합니다.
+ * ```typescript
+ * canBeChosung(
+ *   // 대상 문자
+ *   character: string
+ * ): boolean
+ * ```
+ * @example
+ * canBeChosung('ㄱ') // true
+ * canBeChosung('ㅃ') // true
+ * canBeChosung('ㄱㅅ') // false
+ * canBeChosung('ㅏ') // false
+ * canBeChosung('가') // false
+ */
+export function canBeChosung(character: string) {
+  return HANGUL_CHARACTERS_BY_FIRST_INDEX.includes(character);
+}
+
+/**
+ * @name canBeJungsung
+ * @description
+ * 인자로 받은 문자가 중성으로 위치할 수 있는 문자인지 검사합니다.
+ * ```typescript
+ * canBeJungsung(
+ *   // 대상 문자
+ *   character: string
+ * ): boolean
+ * ```
+ * @example
+ * canBeChosung('ㅏ') // true
+ * canBeChosung('ㅗㅏ') // true
+ * canBeChosung('ㅏㅗ') // false
+ * canBeChosung('ㄱ') // false
+ * canBeChosung('ㄱㅅ') // false
+ * canBeChosung('가') // false
+ */
+export function canBeJungsung(character: string) {
+  return HANGUL_CHARACTERS_BY_MIDDLE_INDEX.includes(character);
+}
+
+/**
+ * @name canBeJongsung
+ * @description
+ * 인자로 받은 문자가 종성으로 위치할 수 있는 문자인지 검사합니다.
+ * ```typescript
+ * canBeJongsung(
+ *   // 대상 문자
+ *   character: string
+ * ): boolean
+ * ```
+ * @example
+ * canBeChosung('ㄱ') // true
+ * canBeChosung('ㄱㅅ') // true
+ * canBeChosung('ㅎㄹ') // false
+ * canBeChosung('가') // false
+ * canBeChosung('ㅏ') // false
+ * canBeChosung('ㅗㅏ') // false
+ */
+export function canBeJongsung(character: string) {
+  return HANGUL_CHARACTERS_BY_LAST_INDEX.includes(character);
 }


### PR DESCRIPTION
## Overview

#24 를 통해 이슈레이징 했던 인자로 문자를 받아 초성, 중성, 종성 위치가 가능한 문자인지 검사하는 함수입니다.

함수의 동작은 소스 내부의 `HANGUL_CHARACTERS_BY_FIRST_INDEX`, `HANGUL_CHARACTERS_BY_MIDDLE_INDEX`, `HANGUL_CHARACTERS_BY_LAST_INDEX`에 종속됩니다.

이처럼 함수의 동작이 `HANGUL_CHARACTERS_BY_FIRST_INDEX`, `HANGUL_CHARACTERS_BY_MIDDLE_INDEX`, `HANGUL_CHARACTERS_BY_LAST_INDEX`의 구성에 종속된다면, `ㅘ`, `ㄳ`과 같은 값은 `false`로 평가되는데요.

이는 곧 라이브러리 내부의 특수한 비즈니스 로직에 종속되는 것이기 때문에 추후 #18 을 구현하기에는 이와 같은 동작이 편리할 수 있지만, 유저가 사용하기에는 다소 헷갈릴 수 있는 동작일 수 있습니다.

`ㄳ` 같은 값은 실제로 유저가 입력하기에는 번거로운 값이기 때문에 `ㄱㅅ`와 같은 형태로 검사하는 것이 합리적이지만,
`ㅘ`와 같이 조합된 모음은 유저가 쉽게 입력할 수 있는 값이기 때문에 어떻게 처리해줘야 할지에 대한 고민이 필요합니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
