### PR TITLE
fix: prevent runtime error in josaPicker when word is empty string

### DIFF
--- a/src/josa.spec.ts
+++ b/src/josa.spec.ts
@@ -73,6 +73,9 @@ describe('Hangul', () => {
   });
 
   describe('josa.pick', () => {
+    it('첫 번째 매개변수가 빈 문자열이라면 옵션중 첫 번째 값을 반환한다', () => {
+      expect(josa.pick('', '이/가')).toBe('이');
+    });
     it('주격조사', () => {
       expect(josa.pick('샴푸', '이/가')).toBe('가');
       expect(josa.pick('칫솔', '이/가')).toBe('이');

--- a/src/josa.ts
+++ b/src/josa.ts
@@ -29,6 +29,10 @@ export function josa(word: string, josa: JosaOption): string {
 josa.pick = josaPicker;
 
 function josaPicker(word: string, josa: JosaOption): string {
+  if (word.length === 0) {
+    return josa.split('/')[0];
+  }
+
   const has받침 = hasBatchim(word);
   let index = has받침 ? 0 : 1;
 

--- a/src/josa.ts
+++ b/src/josa.ts
@@ -32,7 +32,7 @@ function josaPicker(word: string, josa: JosaOption): string {
   const has받침 = hasBatchim(word);
   let index = has받침 ? 0 : 1;
 
-  const is종성ㄹ = disassembleCompleteHangulCharacter(word[word.length - 1]!)?.last === 'ㄹ';
+  const is종성ㄹ = disassembleCompleteHangulCharacter(word[word.length - 1])?.last === 'ㄹ';
 
   const isCaseOf로 = has받침 && is종성ㄹ && 로_조사.includes(josa);
 
@@ -46,5 +46,5 @@ function josaPicker(word: string, josa: JosaOption): string {
     index = 1;
   }
 
-  return josa.split('/')[index]!;
+  return josa.split('/')[index];
 }


### PR DESCRIPTION
## Overview

`josaPicker` 함수의 `word` 매개변수가 빈 문자열일 경우 발생할 수 있는 런타임 오류를 방지하기 위한 로직을 추가했습니다.
매개변수 `word`의 길이가 0(`""`)일 때 첫 번째 조사를 반환`(이/가 중 이)`하여 undefined에 접근하는 경우를 제거는 것으로 런타임 에러를 방지합니다.

추가적으로 `josa.ts`파일에서 불필요한 `non null assertion` 연산자를 제거했습니다.
이 외 배열의 요소에 접근할 때 `non null assertion`을 붙여준 경우를 종종 발견했습니다.
```ts
// utils.ts의 hasBatchim 함수
const lastChar = str[str.length - 1]!;

// disassembleCompleteHangulCharacter.ts의 반환 값
HANGUL_CHARACTERS_BY_FIRST_INDEX[firstIndex]!
```

타입스크립트에서 배열이나 문자열에 인덱스를 사용하여 접근할 때, 해당 인덱스의 값이 존재한다고 가정하기 때문에 `non null assertion`이 아무 역할도 하지 못하는 걸로 알고 있습니다.

그럼에도 이처럼 `non null assertion`을 붙여주는 의도에 대해서 여쭤보고 싶습니다!

감사합니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
