### PR TITLE
fix: Handle spaces in initialConsonants search inputs properly

### DIFF
--- a/.changeset/kind-pianos-thank.md
+++ b/.changeset/kind-pianos-thank.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+fix: Handle spaces in initialConsonants search inputs properly

--- a/src/chosungIncludes.spec.ts
+++ b/src/chosungIncludes.spec.ts
@@ -22,6 +22,10 @@ describe('chosungIncludes', () => {
     expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(true);
   });
 
+  it('should return true when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching " "', () => {
+    expect(chosungIncludes('프론트엔드 개발자', ' ')).toBe(false);
+  });
+
   it('should return false when "푸롴트" is entered for searching "프론트엔드" as it does not only include the initial consonants.', () => {
     expect(chosungIncludes('프론트엔드', '푸롴트')).toBe(false);
   });

--- a/src/chosungIncludes.spec.ts
+++ b/src/chosungIncludes.spec.ts
@@ -14,6 +14,14 @@ describe('chosungIncludes', () => {
     expect(chosungIncludes('프론트엔드', 'ㅍㅌ')).toBe(false);
   });
 
+  it('should return true when "ㅍㄹㅌㅇㄷㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
+    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷㄱㅂㅈ')).toBe(true);
+  });
+
+  it('should return true when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
+    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(true);
+  });
+
   it('should return false when "푸롴트" is entered for searching "프론트엔드" as it does not only include the initial consonants.', () => {
     expect(chosungIncludes('프론트엔드', '푸롴트')).toBe(false);
   });

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -18,7 +18,12 @@ export function chosungIncludes(x: string, y: string) {
  * @description 문자열이 한글초성으로만 주어진 경우
  */
 function isOnlyInitialConsonant(str: string) {
-  return disassembleHangulToGroups(str).every(disassembled => {
+  const groups = disassembleHangulToGroups(str);
+  if (groups.length === 0) {
+    return false;
+  }
+
+  return groups.every(disassembled => {
     return disassembled.length === 1 && canBeChosung(disassembled[0]);
   });
 }

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -2,7 +2,7 @@ import { disassembleHangulToGroups } from './disassemble';
 import { canBeChosung, getFirstConsonants } from './utils';
 
 export function chosungIncludes(x: string, y: string) {
-  const trimY = y.replace(/\s/g, '');
+  const trimmedY = y.replace(/\s/g, '');
 
   if (!isOnlyInitialConsonant(trimY)) {
     return false;

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -1,4 +1,3 @@
-import { HANGUL_CHARACTERS_BY_FIRST_INDEX } from './constants';
 import { disassembleHangulToGroups } from './disassemble';
 import { canBeChosung, getFirstConsonants, hasValueInReadOnlyStringList } from './utils';
 
@@ -14,10 +13,12 @@ export function chosungIncludes(x: string, y: string) {
 }
 
 /*
- * @description 한글초성으로만 주어진 경우
+ * @description 공백을 제외한 문자열이 한글초성으로만 주어진 경우
  */
 function isOnlyInitialConsonant(str: string) {
-  return disassembleHangulToGroups(str).every(disassembled => {
+  const trimStr = str.replace(/\s/g, '');
+
+  return disassembleHangulToGroups(trimStr).every(disassembled => {
     return disassembled.length === 1 && canBeChosung(disassembled[0]);
   });
 }

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -2,23 +2,23 @@ import { disassembleHangulToGroups } from './disassemble';
 import { canBeChosung, getFirstConsonants } from './utils';
 
 export function chosungIncludes(x: string, y: string) {
-  if (!isOnlyInitialConsonant(y)) {
+  const trimY = y.replace(/\s/g, '');
+
+  if (!isOnlyInitialConsonant(trimY)) {
     return false;
   }
 
   const initialConsonantsX = getFirstConsonants(x).replace(/\s/g, '');
-  const initialConsonantsY = getFirstConsonants(y).replace(/\s/g, '');
+  const initialConsonantsY = trimY;
 
   return initialConsonantsX.includes(initialConsonantsY);
 }
 
 /*
- * @description 공백을 제외한 문자열이 한글초성으로만 주어진 경우
+ * @description 문자열이 한글초성으로만 주어진 경우
  */
 function isOnlyInitialConsonant(str: string) {
-  const trimStr = str.replace(/\s/g, '');
-
-  return disassembleHangulToGroups(trimStr).every(disassembled => {
+  return disassembleHangulToGroups(str).every(disassembled => {
     return disassembled.length === 1 && canBeChosung(disassembled[0]);
   });
 }

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -4,12 +4,12 @@ import { canBeChosung, getFirstConsonants } from './utils';
 export function chosungIncludes(x: string, y: string) {
   const trimmedY = y.replace(/\s/g, '');
 
-  if (!isOnlyInitialConsonant(trimY)) {
+  if (!isOnlyInitialConsonant(trimmedY)) {
     return false;
   }
 
   const initialConsonantsX = getFirstConsonants(x).replace(/\s/g, '');
-  const initialConsonantsY = trimY;
+  const initialConsonantsY = trimmedY;
 
   return initialConsonantsX.includes(initialConsonantsY);
 }

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -1,5 +1,5 @@
 import { disassembleHangulToGroups } from './disassemble';
-import { canBeChosung, getFirstConsonants, hasValueInReadOnlyStringList } from './utils';
+import { canBeChosung, getFirstConsonants } from './utils';
 
 export function chosungIncludes(x: string, y: string) {
   if (!isOnlyInitialConsonant(y)) {


### PR DESCRIPTION
## Overview

#41 에서 발견한 '공백이 포함된 초성 검색 시 예상치 못한 false 반환 문제'를 공백 포함 입력도 정상적으로 처리하도록 수정했습니다.

- 공백을 포함한 초성 입력시에도 정상적으로 작동하도록 수정
- 공백을 포함한 초성 입력시에도 정상적으로 작동하는지 체크하기 위한 테스트 케이스 추가


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
