### PR TITLE
feat: removeLastHangulCharacter 추가

### DIFF
--- a/.changeset/smooth-tips-yawn.md
+++ b/.changeset/smooth-tips-yawn.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": minor
+---
+
+feat: removeLastHangulCharacter 추가

--- a/src/_internal.ts
+++ b/src/_internal.ts
@@ -1,0 +1,4 @@
+export function excludeLastElement(array: string[]): [string[], string] {
+  const lastElement = array.at(-1);
+  return [array.slice(0, -1), lastElement ?? ''];
+}

--- a/src/removeLastHangulCharacter.spec.ts
+++ b/src/removeLastHangulCharacter.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { removeLastHangulCharacter } from './removeLastHangulCharacter';
 
-describe('removeLastCharacter', () => {
+describe('removeLastHangulCharacter', () => {
   it('마지막 문자가 겹받침인 경우 홑받침으로 바꾼다', () => {
     expect(removeLastHangulCharacter('안녕하세요 값')).toBe('안녕하세요 갑');
   });

--- a/src/removeLastHangulCharacter.spec.ts
+++ b/src/removeLastHangulCharacter.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { removeLastHangulCharacter } from './removeLastHangulCharacter';
+
+describe('removeLastCharacter', () => {
+  it('마지막 문자가 겹받침인 경우 홑받침으로 바꾼다', () => {
+    expect(removeLastHangulCharacter('안녕하세요 값')).toBe('안녕하세요 갑');
+  });
+  it('마지막 문자가 초성과 중성의 조합으로 끝날 경우 초성만 남긴다', () => {
+    expect(removeLastHangulCharacter('프론트엔드')).toBe('프론트엔ㄷ');
+  });
+  it('마지막 문자가 초성과 중성과 종성의 조합으로 끝날 경우 초성과 중성이 조합된 문자만 남긴다.', () => {
+    expect(removeLastHangulCharacter('일요일')).toBe('일요이');
+    expect(removeLastHangulCharacter('깎')).toBe('까');
+  });
+});

--- a/src/removeLastHangulCharacter.ts
+++ b/src/removeLastHangulCharacter.ts
@@ -1,0 +1,42 @@
+import { combineHangulCharacter } from './combineHangulCharacter';
+import { disassembleHangulToGroups } from './disassemble';
+import { excludeLastElement } from './_internal';
+
+/**
+ * @name removeLastHangulCharacter
+ * @description
+ * 인자로 주어진 한글 문자열에서 가장 마지막 문자 하나를 제거하여 반환합니다.
+ * ```typescript
+ * removeLastHangulCharacter(
+ *   // 한글 문자열
+ *   words: string
+ * ): string
+ * ```
+ * @example
+ * removeLastHangulCharacter('안녕하세요 값') // 안녕하세요 갑
+ * removeLastHangulCharacter('프론트엔드') // 프론트엔ㄷ
+ * removeLastHangulCharacter('일요일') // 일요이
+ */
+export function removeLastHangulCharacter(words: string) {
+  const disassembedGroups = disassembleHangulToGroups(words);
+  const lastCharacter = disassembedGroups.at(-1);
+
+  if (lastCharacter == null) {
+    return '';
+  }
+
+  const withoutLastCharacter = disassembedGroups
+    .filter(v => v !== lastCharacter)
+    .map(([first, middle, last]) => {
+      if (middle != null) {
+        return combineHangulCharacter(first, middle, last);
+      }
+
+      return first;
+    });
+
+  const [[first, middle, last]] = excludeLastElement(lastCharacter);
+  const result = middle != null ? combineHangulCharacter(first, middle, last) : first;
+
+  return [...withoutLastCharacter, result].join('');
+}


### PR DESCRIPTION
## Overview

인자로 받은 한글 문자열에서 마지막 한글 문자 하나를 제거하여 반환하는 `removeLastHangulCharacter` 함수를 추가합니다.

```ts
removeLastHangulCharacter('안녕하세요 값') // '안녕하세요 갑'
removeLastHangulCharacter('프론트엔드') // '프론트엔ㄷ'
removeLastHangulCharacter('일요일') // '일요이'
```

이 함수는 개별적으로 사용되기도 하겠지만, https://github.com/toss/es-hangul/issues/18 에서 제안된 `assemble` 함수의 연음법칙을 구현할 때도 사용됩니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
