### PR TITLE
fix: chosungIncludes에서 불필요한 로직을 제거하고 테스트 코드, 문서 추가

### DIFF
--- a/docs/src/pages/docs/api/chosungIncludes.md
+++ b/docs/src/pages/docs/api/chosungIncludes.md
@@ -15,9 +15,26 @@ function chosungIncludes(
 ): boolean;
 ```
 
+## Examples
+
 ```typescript
 chosungIncludes('프론트엔드', 'ㅍㄹㅌ'); // true
 chosungIncludes('00프론트엔드', 'ㅍㄹㅌ'); // true
 chosungIncludes('프론트엔드', 'ㅍㅌ'); // false
 chosungIncludes('프론트엔드', '푸롴트'); // false
+chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ'); // false
+```
+
+## Tips
+
+공백을 포함한 단어의 검색도 처리하고 싶다면, 다음과 같이 사용해보세요!
+
+```ts
+const word = '프론트엔드 개발자';
+const chosung = 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ';
+
+const trimmedWord = word.replace(/\s/g, '');
+const trimmedChosung = chosung.replace(/\s/g, '');
+
+const 유저가_입력한_초성이_단어에_맞는가 = chosungIncludes(trimmedWord, trimmedChosung);
 ```

--- a/src/chosungIncludes.spec.ts
+++ b/src/chosungIncludes.spec.ts
@@ -14,6 +14,10 @@ describe('chosungIncludes', () => {
     expect(chosungIncludes('프론트엔드', 'ㅍㅌ')).toBe(false);
   });
 
+  it('should return false when "ㅍㅌㅌㅇㄷ ㄱㅂㅈ" is entered for searching "프론트엔드 개발자" as the function does not support spaces in the input', () => {
+    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(false);
+  });
+
   it('should return false when "푸롴트" is entered for searching "프론트엔드" as it does not only include the initial consonants.', () => {
     expect(chosungIncludes('프론트엔드', '푸롴트')).toBe(false);
   });

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -1,6 +1,5 @@
-import { HANGUL_CHARACTERS_BY_FIRST_INDEX } from './constants';
 import { disassembleHangulToGroups } from './disassemble';
-import { canBeChosung, getFirstConsonants, hasValueInReadOnlyStringList } from './utils';
+import { canBeChosung, getFirstConsonants } from './utils';
 
 export function chosungIncludes(x: string, y: string) {
   if (!isOnlyInitialConsonant(y)) {
@@ -8,7 +7,7 @@ export function chosungIncludes(x: string, y: string) {
   }
 
   const initialConsonantsX = getFirstConsonants(x).replace(/\s/g, '');
-  const initialConsonantsY = getFirstConsonants(y).replace(/\s/g, '');
+  const initialConsonantsY = getFirstConsonants(y);
 
   return initialConsonantsX.includes(initialConsonantsY);
 }


### PR DESCRIPTION
## Overview

#41  에서 발견한 '공백이 포함된 초성 검색 시 예상치 못한 false 반환 문제'를 코멘트의 의견을 반영하여 다음과 같이 개선했습니다.
- https://github.com/toss/es-hangul/issues/41#issuecomment-2059209776

# 기존코드
```ts
const initialConsonantsY = getFirstConsonants(y).replace(/\s/g, '');
```

`isOnlyInitialConsonant` 함수는 인자로 받는 문자열에 공백이 포함되면 반드시 false를 반환합니다. 따라서 `initialConsonantsY`에서 공백을 제거하는 것은 불필요합니다.

따라서, 더 나은 사용자 경험을 위해 띄어쓰기까지 고려하는 것을 서비스 개발자에게 맡긴다면, 다음과 같이 개선할 수 있을 것 같습니다.

# 개선하기

## 1. 불필요한 공백 제거 로직을 제외한다
```ts
const initialConsonantsY = getFirstConsonants(y);
```

## 2. 문서화의 역할을 겸하는 테스트코드를 추가한다
```ts
it('should return false when "ㅍㅌㅌㅇㄷ ㄱㅂㅈ" is entered for searching "프론트엔드 개발자" as the function does not support spaces in the input', () => {
    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(false);
  });
```

## 3. `chosungIncludes.md`에 공백이 포함된 문자열에서 사용하는 방법을 예시로 추가한다.

## Tips

공백을 포함한 단어도 처리하고 싶다면, 다음과 같이 사용해보세요!

```tsx
const word = '프론트엔드 개발자';
const chosung = 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ';

const trimmedWord = word.replace(/\s/g, '');
const trimmedChosung = chosung.replace(/\s/g, '');

const 유저가_입력한_초성이_단어에_맞는가 = chosungIncludes(trimmedWord, trimmedChosung);
```

## 참고사항
#41 에서 제기한 이슈를 #42 와 다른 관점으로 개선한 PR입니다.
- #42 의 경우에는  '공백이 포함된 초성 검색 시 예상치 못한 false 반환 문제'를 공백 포함 입력도 정상적으로 처리하도록 수정
- 이 PR의 경우에는 서비스 개발자에게 테스트코드와 문서로 가이드를 제공함과 동시에 로직에서 불필요한 코드를 제거했습니다.

감사합니다 🙂

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
