### PR TITLE
feat: Tagged templates 방식으로 josa 함수를 사용할 수 있는 taggedJosa 추가

### DIFF
--- a/src/josa.spec.ts
+++ b/src/josa.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { josa } from './josa';
+import { josa, taggedJosa } from './josa';
 
 describe('Hangul', () => {
   describe('josa', () => {
@@ -142,6 +142,26 @@ describe('Hangul', () => {
     });
     it('어떤 행동의 출발점이나 비롯되는 대상임을 나타내는 격 조사 ㄹ 받침 예외처리', () => {
       expect(josa.pick('동굴', '으로부터/로부터')).toBe('로부터');
+    });
+  });
+
+  describe('taggedJosa', () => {
+    it('prefix만 있는 경우', () => {
+      expect(taggedJosa`나는 프론트엔드 ${['개발자', '이에요/예요']}`).toBe('나는 프론트엔드 개발자예요');
+    });
+
+    it('suffix만 있는 경우', () => {
+      expect(taggedJosa`${['개발자', '은/는']} 여러 전문 분야가 있어요.`).toBe('개발자는 여러 전문 분야가 있어요.');
+    });
+
+    it('prefix와 suffix가 모두 있는 경우', () => {
+      expect(taggedJosa`es-hangul은 쉽게 ${['한글', '을/를']} 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.`).toBe(
+        'es-hangul은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.'
+      );
+    });
+
+    it('빈 문자열이 들어온 경우', () => {
+      expect(() => taggedJosa`${['', '은/는']} 조사를 가질 수 없어요`).toThrowError;
     });
   });
 });

--- a/src/josa.spec.ts
+++ b/src/josa.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { josa, taggedJosa } from './josa';
+import { josa } from './josa';
 
 describe('Hangul', () => {
   describe('josa', () => {
@@ -145,23 +145,23 @@ describe('Hangul', () => {
     });
   });
 
-  describe('taggedJosa', () => {
+  describe('josa.tagged', () => {
     it('prefix만 있는 경우', () => {
-      expect(taggedJosa`나는 프론트엔드 ${['개발자', '이에요/예요']}`).toBe('나는 프론트엔드 개발자예요');
+      expect(josa.tagged`나는 프론트엔드 ${['개발자', '이에요/예요']}`).toBe('나는 프론트엔드 개발자예요');
     });
 
     it('suffix만 있는 경우', () => {
-      expect(taggedJosa`${['개발자', '은/는']} 여러 전문 분야가 있어요.`).toBe('개발자는 여러 전문 분야가 있어요.');
+      expect(josa.tagged`${['개발자', '은/는']} 여러 전문 분야가 있어요.`).toBe('개발자는 여러 전문 분야가 있어요.');
     });
 
     it('prefix와 suffix가 모두 있는 경우', () => {
-      expect(taggedJosa`es-hangul은 쉽게 ${['한글', '을/를']} 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.`).toBe(
+      expect(josa.tagged`es-hangul은 쉽게 ${['한글', '을/를']} 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.`).toBe(
         'es-hangul은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다.'
       );
     });
 
     it('빈 문자열이 들어온 경우', () => {
-      expect(() => taggedJosa`${['', '은/는']} 조사를 가질 수 없어요`).toThrowError;
+      expect(() => josa.tagged`${['', '은/는']} 조사를 가질 수 없어요`).toThrowError;
     });
   });
 });

--- a/src/josa.ts
+++ b/src/josa.ts
@@ -29,6 +29,10 @@ export function josa(word: string, josa: JosaOption): string {
 export function taggedJosa(strings: TemplateStringsArray, [word, josa]: [string, JosaOption]) {
   const [prefix, suffix] = strings;
 
+  if (word.length === 0) {
+    throw new Error('빈 문자열에 조사를 붙일 수 없습니다.');
+  }
+
   const chosenJosa = josaPicker(word, josa);
 
   return prefix + word + chosenJosa + suffix;

--- a/src/josa.ts
+++ b/src/josa.ts
@@ -25,20 +25,8 @@ export function josa(word: string, josa: JosaOption): string {
 
   return word + josaPicker(word, josa);
 }
-
-export function taggedJosa(strings: TemplateStringsArray, [word, josa]: [string, JosaOption]) {
-  const [prefix, suffix] = strings;
-
-  if (word.length === 0) {
-    throw new Error('빈 문자열에 조사를 붙일 수 없습니다.');
-  }
-
-  const chosenJosa = josaPicker(word, josa);
-
-  return prefix + word + chosenJosa + suffix;
-}
-
 josa.pick = josaPicker;
+josa.tagged = taggedJosa;
 
 function josaPicker(word: string, josa: JosaOption): string {
   if (word.length === 0) {
@@ -63,4 +51,16 @@ function josaPicker(word: string, josa: JosaOption): string {
   }
 
   return josa.split('/')[index];
+}
+
+export function taggedJosa(strings: TemplateStringsArray, [word, josa]: [string, JosaOption]) {
+  const [prefix, suffix] = strings;
+
+  if (word.length === 0) {
+    throw new Error('빈 문자열에 조사를 붙일 수 없습니다.');
+  }
+
+  const chosenJosa = josaPicker(word, josa);
+
+  return prefix + word + chosenJosa + suffix;
 }

--- a/src/josa.ts
+++ b/src/josa.ts
@@ -26,6 +26,14 @@ export function josa(word: string, josa: JosaOption): string {
   return word + josaPicker(word, josa);
 }
 
+export function taggedJosa(strings: TemplateStringsArray, [word, josa]: [string, JosaOption]) {
+  const [prefix, suffix] = strings;
+
+  const chosenJosa = josaPicker(word, josa);
+
+  return prefix + word + chosenJosa + suffix;
+}
+
 josa.pick = josaPicker;
 
 function josaPicker(word: string, josa: JosaOption): string {


### PR DESCRIPTION
## Overview
- Tagged templates 방식으로 선언적으로 조사를  붙여주는 `taggedJosa` 함수를 `josa.tagged`로 추가했습니다. 
- `josa.tagged`를 위한 테스트 케이스를 추가했습니다.

`josa.tagged`을 사용한다면 다음과 마치 한글을 읽듯이 가독성 좋게 코드를 작성할 수 있을것이라고 기대합니다.

### `josa` 함수를 사용해 문장을 만드는 방법
```ts
const job = '개발자'

const sentence = `제 직업은 ${josa(job, '이에요/예요')}!`
```

### `josa.tagged` 함수를 사용해 문장을 만드는 방법
```ts
const job = '개발자'

const sentence = josa.tagged`제 직업은 ${[job,'이에요/예요']}!
```


### 참고사항
1. 빈 문자열을 검사하는 방식에는 다음과 같은 두 가지 개선 방법이 있을 것 같습니다.
  -  NonEmptyString 등의 커스텀 타입을 만들고 해당 타입에 대한 타입가드를 만들어서 처리하는 방식
  -  `josa`에서도 throw Error을 던져주는 방식으로 동일하게 처리
  ```ts
  if (word.length === 0) {
      throw new Error('빈 문자열에 조사를 붙일 수 없습니다.');
    }
  ```

2. 추가된 `josa.tagged`의 개발경험이 좋았다면, 조금 더 발전시켜서 `josa.tagged`내에서 여러 번 조사를 처리해주도록 발전도 가능합니다!
```ts
const name = '홍길동'
const job = '개발자'

josa.tagged`${[name,'은/는']} ${[job,'이에요/예요']}!
```

### ...rest
- [Tagged templates](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Template_literals#tagged_templates)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
