### PR TITLE
fix: convertQwertyToHangul split 및 Non-null assertion operator 제거, 네이밍 오타 수정

### DIFF
--- a/.changeset/young-bears-double.md
+++ b/.changeset/young-bears-double.md
@@ -1,0 +1,5 @@
+---
+"es-hangle": patch
+---
+
+refac: convertQwertyToHangul split 및 Non-null assertion operator 제거, 네이밍 오타 수정

--- a/src/convertQwertyToHangulAlphabet.ts
+++ b/src/convertQwertyToHangulAlphabet.ts
@@ -27,5 +27,5 @@ export function convertQwertyToHangul(word: string): string {
   if (!word) {
     return '';
   }
-  return assembleHangul([...convertQwertyToHangulAlphabet(word).split('')]);
+  return assembleHangul([...convertQwertyToHangulAlphabet(word)]);
 }

--- a/src/disassembleCompleteHangulCharacter.ts
+++ b/src/disassembleCompleteHangulCharacter.ts
@@ -32,8 +32,8 @@ export function disassembleCompleteHangulCharacter(
   const firstIndex = Math.floor((hangulCode - lastIndex) / NUMBER_OF_JONGSUNG / NUMBER_OF_JUNGSUNG);
 
   return {
-    first: HANGUL_CHARACTERS_BY_FIRST_INDEX[firstIndex]!,
-    middle: HANGUL_CHARACTERS_BY_MIDDLE_INDEX[middleIndex]!,
-    last: HANGUL_CHARACTERS_BY_LAST_INDEX[lastIndex]!,
+    first: HANGUL_CHARACTERS_BY_FIRST_INDEX[firstIndex],
+    middle: HANGUL_CHARACTERS_BY_MIDDLE_INDEX[middleIndex],
+    last: HANGUL_CHARACTERS_BY_LAST_INDEX[lastIndex],
   } as const;
 }

--- a/src/removeLastHangulCharacter.ts
+++ b/src/removeLastHangulCharacter.ts
@@ -18,14 +18,14 @@ import { excludeLastElement } from './_internal';
  * removeLastHangulCharacter('일요일') // 일요이
  */
 export function removeLastHangulCharacter(words: string) {
-  const disassembedGroups = disassembleHangulToGroups(words);
-  const lastCharacter = disassembedGroups.at(-1);
+  const disassembledGroups = disassembleHangulToGroups(words);
+  const lastCharacter = disassembledGroups.at(-1);
 
   if (lastCharacter == null) {
     return '';
   }
 
-  const withoutLastCharacter = disassembedGroups
+  const withoutLastCharacter = disassembledGroups
     .filter(v => v !== lastCharacter)
     .map(([first, middle, last]) => {
       if (middle != null) {


### PR DESCRIPTION
## Overview

기존 코드를 보다가 일부 코드 및 오타를 수정하였습니다.

1. `convertQwertyToHangulAlphabet` 함수가 반환하는 문자열은 `iterable`이기 때문에 `전개 연산자(...)`에 활용 될 수 있습니다. 현재 코드만 봤을 때 `split('')`을 통해 한번 더 배열로 변환 하는 것은 불 필요하지 않을까 생각합니다🙏 cc. @99mini 

```tsx
const str = "프론트엔드";
const arr = ["프", "론", "트", "엔", "드"];

console.log([...str]); // [ '프', '론', '트', '엔', '드' ]
console.log([...arr]); // [ '프', '론', '트', '엔', '드' ]

console.log([...str.split('')]); // [ '프', '론', '트', '엔', '드' ]
```

2. 더 이상 타입 에러를 발생시키지 않기 때문에 `Non-null assertion operator(!)`를 제거했습니다!
3. disassembedGroups -> disassembledGroups 오타 수정

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
