### PR TITLE
docs(README.md, README-en_us.md): 리드미 내의 링크 수정

### DIFF
--- a/README-en_us.md
+++ b/README-en_us.md
@@ -2,7 +2,7 @@
 
 # es-hangul
 
-[한국어](./README.md) | English
+[한국어](https://github.com/toss/es-hangul/blob/main/README.md) | English
 
 es-hangul is a library that makes it easy to handle [Hangul](https://en.wikipedia.org/wiki/Hangul) in JavaScript. It provides a modern API that is easy to use. Because it uses ECMAScript Modules, users can download the minimum amount of code when used in a browser environment.
 
@@ -35,11 +35,11 @@ console.log(sentence2); // '바나나가 맛있습니다.'
 
 We welcome contribution from everyone in the community. Read below for detailed contribution guide.
 
-[CONTRIBUTING](./.github/CONTRIBUTING.md)
+[CONTRIBUTING](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
 
 ## License
 
-MIT © Viva Republica, Inc. See [LICENSE](./LICENSE) for details.
+MIT © Viva Republica, Inc. See [LICENSE](https://github.com/toss/es-hangul/blob/main/LICENSE) for details.
 
 <a title="토스" href="https://toss.im">
   <picture>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # es-hangul
 
-한국어 | [English](./README-en_us.md)
+한국어 | [English](https://github.com/toss/es-hangul/blob/main/README-en_us.md)
 
 `es-hangul`은 쉽게 한글을 다룰 수 있도록 돕는 JavaScript 라이브러리입니다. 편리하게 사용할 수 있는 모던한 라이브러리 API를 제공합니다. ECMAScript Modules을 사용하기 때문에, 사용자가 브라우저 환경에서 최소한의 코드를 내려받도록 할 수 있습니다.
 
@@ -35,11 +35,11 @@ console.log(sentence2); // '바나나가 맛있습니다.'
 
 es-hangul 라이브러리에 기여하고 싶다고 생각하셨다면 아래 문서를 참고해주세요.
 
-[CONTRIBUTING](./.github/CONTRIBUTING.md)
+[CONTRIBUTING](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
 
 ## 라이선스
 
-MIT © Viva Republica, Inc. [LICENSE](./LICENSE) 파일을 참고하세요.
+MIT © Viva Republica, Inc. [LICENSE](https://github.com/toss/es-hangul/blob/main/LICENSE) 파일을 참고하세요.
 
 <a title="토스" href="https://toss.im">
   <picture>


### PR DESCRIPTION
## Overview

리드미 문서 내 URL의 상대경로를 절대 경로로 수정하여
외부 경로([es-hangul npm](https://www.npmjs.com/package/es-hangul) 등)에서 `CONTRIBUTING.md`, `README.md`, `README-en_us.md`등의 파일에 접근가능하도록 수정하였습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
