### PR TITLE
chore: vitest globals option 활성화

### DIFF
--- a/src/_internal/hangul.spec.ts
+++ b/src/_internal/hangul.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, assert } from 'vitest';
 import { binaryAssembleHangulCharacters, binaryAssembleHangul, isHangulAlphabet, isHangulCharacter } from './hangul';
 
 describe('isHangul*', () => {

--- a/src/assemble.spec.ts
+++ b/src/assemble.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { assembleHangul } from './assemble';
 
 describe('assembleHangul', () => {

--- a/src/chosungIncludes.spec.ts
+++ b/src/chosungIncludes.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { chosungIncludes } from './chosungIncludes';
 
 describe('chosungIncludes', () => {

--- a/src/combineHangulCharacter.spec.ts
+++ b/src/combineHangulCharacter.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, assert } from 'vitest';
 import { combineHangulCharacter, combineVowels } from './combineHangulCharacter';
 
 describe('combineHangulCharacter', () => {

--- a/src/convertQwertyToHangulAlphabet.spec.ts
+++ b/src/convertQwertyToHangulAlphabet.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { convertQwertyToHangul, convertQwertyToHangulAlphabet } from './convertQwertyToHangulAlphabet';
 
 describe('convertQwertyToHangulAlphabet', () => {

--- a/src/disassemble.spec.ts
+++ b/src/disassemble.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { disassembleHangul, disassembleHangulToGroups } from './disassemble';
 
 describe('disassembleHangulToGroups', () => {

--- a/src/disassembleCompleteHangulCharacter.spec.ts
+++ b/src/disassembleCompleteHangulCharacter.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { disassembleCompleteHangulCharacter } from './disassembleCompleteHangulCharacter';
 
 describe('disassembleCompleteHangulCharacter', () => {

--- a/src/hangulIncludes.spec.ts
+++ b/src/hangulIncludes.spec.ts
@@ -1,5 +1,4 @@
 import { hangulIncludes } from './hangulIncludes';
-import { describe, it, expect } from 'vitest';
 
 describe('hangulIncludes', () => {
   it('사과', () => {

--- a/src/josa.spec.ts
+++ b/src/josa.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest';
 import { josa } from './josa';
 
 describe('Hangul', () => {

--- a/src/removeLastHangulCharacter.spec.ts
+++ b/src/removeLastHangulCharacter.spec.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from 'vitest';
 import { removeLastHangulCharacter } from './removeLastHangulCharacter';
 
 describe('removeLastHangulCharacter', () => {

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, expectTypeOf, it } from 'vitest';
 import {
   canBeChosung,
   canBeJongsung,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["vitest/globals"],
     "target": "es2016",
     "module": "commonjs",
     "esModuleInterop": true,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     name: packageJson.name,
     dir: './src',
+    globals: true,
     coverage: {
       provider: 'istanbul',
       include: ['src/**/*'],


### PR DESCRIPTION
## Overview

vitest는 jest와 같이 기본적으로 global API를 활성화하지 않지만 vitest.config에서 `globals` 옵션을 활성화 할 수 있습니다.

이를 통해 각 테스트 파일에 직접 `describe`, `it`, `expect`를 import 해야되는 수고로움을 덜어 테스트 코드를 작성 시 개발자 경험을 향상시킬 수 있을 것 같습니다. 

추가적으로 typescript와 함께 사용하기위해 tsconfig에 `vitest/globals` 을 추가 할 수 있습니다.

하지만 명시적으로 import 하는 것을 선호할 수 있습니다! 의견주시면 감사드립니다 🤗

https://vitest.dev/config/#globals

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
