### PR TITLE
test: 테스트 관심사에 따른 describe 세분화

### DIFF
--- a/src/chosungIncludes.spec.ts
+++ b/src/chosungIncludes.spec.ts
@@ -1,31 +1,35 @@
 import { chosungIncludes } from './chosungIncludes';
 
 describe('chosungIncludes', () => {
-  it('should return true when "ㅍㄹㅌ" is entered for searching "프론트엔드"', () => {
-    expect(chosungIncludes('프론트엔드', 'ㅍㄹㅌ')).toBe(true);
+  describe('초성이 포함되어있다고 판단되는 경우', () => {
+    it('should return true when "ㅍㄹㅌ" is entered for searching "프론트엔드"', () => {
+      expect(chosungIncludes('프론트엔드', 'ㅍㄹㅌ')).toBe(true);
+    });
+
+    it('should return true when "ㅍㄹㅌ" is entered for searching "00프론트엔드"', () => {
+      expect(chosungIncludes('00프론트엔드', 'ㅍㄹㅌ')).toBe(true);
+    });
+
+    it('should return true when "ㅍㄹㅌㅇㄷㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
+      expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷㄱㅂㅈ')).toBe(true);
+    });
+
+    it('should return true when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
+      expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(true);
+    });
   });
 
-  it('should return true when "ㅍㄹㅌ" is entered for searching "00프론트엔드"', () => {
-    expect(chosungIncludes('00프론트엔드', 'ㅍㄹㅌ')).toBe(true);
-  });
+  describe('초성이 포함되어있다고 판단되지 않는 경우', () => {
+    it('should return false when "ㅍㅌ" is entered for searching "프론트엔드"', () => {
+      expect(chosungIncludes('프론트엔드', 'ㅍㅌ')).toBe(false);
+    });
 
-  it('should return false when "ㅍㅌ" is entered for searching "프론트엔드"', () => {
-    expect(chosungIncludes('프론트엔드', 'ㅍㅌ')).toBe(false);
-  });
+    it('should return false when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching " "', () => {
+      expect(chosungIncludes('프론트엔드 개발자', ' ')).toBe(false);
+    });
 
-  it('should return true when "ㅍㄹㅌㅇㄷㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
-    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷㄱㅂㅈ')).toBe(true);
-  });
-
-  it('should return true when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
-    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(true);
-  });
-
-  it('should return true when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching " "', () => {
-    expect(chosungIncludes('프론트엔드 개발자', ' ')).toBe(false);
-  });
-
-  it('should return false when "푸롴트" is entered for searching "프론트엔드" as it does not only include the initial consonants.', () => {
-    expect(chosungIncludes('프론트엔드', '푸롴트')).toBe(false);
+    it('should return false when "푸롴트" is entered for searching "프론트엔드" as it does not only include the initial consonants.', () => {
+      expect(chosungIncludes('프론트엔드', '푸롴트')).toBe(false);
+    });
   });
 });

--- a/src/hangulIncludes.spec.ts
+++ b/src/hangulIncludes.spec.ts
@@ -1,20 +1,30 @@
 import { hangulIncludes } from './hangulIncludes';
 
 describe('hangulIncludes', () => {
-  it('사과', () => {
-    expect(hangulIncludes('사과', '')).toBe(true);
-    expect(hangulIncludes('사과', 'ㅅ')).toBe(true);
-    expect(hangulIncludes('사과', '삭')).toBe(true);
-    expect(hangulIncludes('사과', '삽')).toBe(false);
-    expect(hangulIncludes('사과', '사과')).toBe(true);
+  describe('한글이 포함되어있다고 판단되는 경우', () => {
+    it('사과', () => {
+      expect(hangulIncludes('사과', '')).toBe(true);
+      expect(hangulIncludes('사과', 'ㅅ')).toBe(true);
+      expect(hangulIncludes('사과', '삭')).toBe(true);
+      expect(hangulIncludes('사과', '사과')).toBe(true);
+    });
+
+    it('프론트엔드', () => {
+      expect(hangulIncludes('프론트엔드', '')).toBe(true);
+      expect(hangulIncludes('프론트엔드', '플')).toBe(true);
+      expect(hangulIncludes('프론트엔드', '틍')).toBe(true);
+      expect(hangulIncludes('프론트엔드', '플')).toBe(true);
+      expect(hangulIncludes('프론트엔드', '프로')).toBe(true);
+    });
   });
 
-  it('프론트엔드', () => {
-    expect(hangulIncludes('프론트엔드', '')).toBe(true);
-    expect(hangulIncludes('프론트엔드', '플')).toBe(true);
-    expect(hangulIncludes('프론트엔드', '틍')).toBe(true);
-    expect(hangulIncludes('프론트엔드', '픏')).toBe(false);
-    expect(hangulIncludes('프론트엔드', '플')).toBe(true);
-    expect(hangulIncludes('프론트엔드', '프로')).toBe(true);
+  describe('한글이 포함되어있다고 판단되지 않는 경우', () => {
+    it('사과', () => {
+      expect(hangulIncludes('사과', '삽')).toBe(false);
+    });
+
+    it('프론트엔드', () => {
+      expect(hangulIncludes('프론트엔드', '픏')).toBe(false);
+    });
   });
 });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -10,20 +10,25 @@ import {
 } from './utils';
 
 describe('hasBatchim', () => {
-  it('should return true for the character "값"', () => {
-    expect(hasBatchim('값')).toBe(true);
+  describe('받침이 있다고 판단되는 경우', () => {
+    it('should return true for the character "값"', () => {
+      expect(hasBatchim('값')).toBe(true);
+    });
+    it('should return true for the character "공"', () => {
+      expect(hasBatchim('공')).toBe(true);
+    });
+    it('should return true for the character "읊"', () => {
+      expect(hasBatchim('읊')).toBe(true);
+    });
   });
-  it('should return true for the character "공"', () => {
-    expect(hasBatchim('공')).toBe(true);
-  });
-  it('should return false for the character "토"', () => {
-    expect(hasBatchim('토')).toBe(false);
-  });
-  it('should return true for the character "읊"', () => {
-    expect(hasBatchim('읊')).toBe(true);
-  });
-  it('should return false for the character "서"', () => {
-    expect(hasBatchim('서')).toBe(false);
+
+  describe('받침이 없다고 판단되는 경우', () => {
+    it('should return false for the character "토"', () => {
+      expect(hasBatchim('토')).toBe(false);
+    });
+    it('should return false for the character "서"', () => {
+      expect(hasBatchim('서')).toBe(false);
+    });
   });
 });
 
@@ -34,14 +39,17 @@ describe('hasSingleBatchim', () => {
     expect(hasSingleBatchim('양')).toBe(true);
     expect(hasSingleBatchim('신')).toBe(true);
   });
-  it('겹받침을 받으면 false를 반환한다.', () => {
-    expect(hasSingleBatchim('값')).toBe(false);
-    expect(hasSingleBatchim('읊')).toBe(false);
-  });
 
-  it('받침이 없는 문자를 받으면 false를 반환한다.', () => {
-    expect(hasSingleBatchim('토')).toBe(false);
-    expect(hasSingleBatchim('서')).toBe(false);
+  describe('홑받침이 아니라고 판단되는 경우', () => {
+    it('겹받침을 받으면 false를 반환한다.', () => {
+      expect(hasSingleBatchim('값')).toBe(false);
+      expect(hasSingleBatchim('읊')).toBe(false);
+    });
+
+    it('받침이 없는 문자를 받으면 false를 반환한다.', () => {
+      expect(hasSingleBatchim('토')).toBe(false);
+      expect(hasSingleBatchim('서')).toBe(false);
+    });
   });
 });
 
@@ -117,64 +125,79 @@ describe('hasProperty', () => {
 });
 
 describe('canBeChosung', () => {
-  it('ㄱ', () => {
-    expect(canBeChosung('ㄱ')).toBe(true);
+  describe('초성이 될 수 있다고 판단되는 경우', () => {
+    it('ㄱ', () => {
+      expect(canBeChosung('ㄱ')).toBe(true);
+    });
+    it('ㅃ', () => {
+      expect(canBeChosung('ㅃ')).toBe(true);
+    });
   });
-  it('ㅃ', () => {
-    expect(canBeChosung('ㅃ')).toBe(true);
-  });
-  it('ㅏ', () => {
-    expect(canBeChosung('ㅏ')).toBe(false);
-  });
-  it('ㅘ', () => {
-    expect(canBeChosung('ㅏ')).toBe(false);
-  });
-  it('ㄱㅅ', () => {
-    expect(canBeChosung('ㅏ')).toBe(false);
-  });
-  it('가', () => {
-    expect(canBeChosung('ㅏ')).toBe(false);
+
+  describe('초성이 될 수 없다고 판단되는 경우', () => {
+    it('ㅏ', () => {
+      expect(canBeChosung('ㅏ')).toBe(false);
+    });
+    it('ㅘ', () => {
+      expect(canBeChosung('ㅏ')).toBe(false);
+    });
+    it('ㄱㅅ', () => {
+      expect(canBeChosung('ㅏ')).toBe(false);
+    });
+    it('가', () => {
+      expect(canBeChosung('ㅏ')).toBe(false);
+    });
   });
 });
 
 describe('canBeJungsung', () => {
-  it('ㅗㅏ', () => {
-    expect(canBeJungsung('ㅗㅏ')).toBe(true);
+  describe('중성이 될 수 있다고 판단되는 경우', () => {
+    it('ㅗㅏ', () => {
+      expect(canBeJungsung('ㅗㅏ')).toBe(true);
+    });
+    it('ㅏ', () => {
+      expect(canBeJungsung('ㅏ')).toBe(true);
+    });
   });
-  it('ㅏ', () => {
-    expect(canBeJungsung('ㅏ')).toBe(true);
-  });
-  it('ㄱ', () => {
-    expect(canBeJungsung('ㄱ')).toBe(false);
-  });
-  it('ㄱㅅ', () => {
-    expect(canBeJungsung('ㄱㅅ')).toBe(false);
-  });
-  it('가', () => {
-    expect(canBeJungsung('가')).toBe(false);
+
+  describe('중성이 될 수 없다고 판단되는 경우', () => {
+    it('ㄱ', () => {
+      expect(canBeJungsung('ㄱ')).toBe(false);
+    });
+    it('ㄱㅅ', () => {
+      expect(canBeJungsung('ㄱㅅ')).toBe(false);
+    });
+    it('가', () => {
+      expect(canBeJungsung('가')).toBe(false);
+    });
   });
 });
 
 describe('canBeJongsung', () => {
-  it('ㄱ', () => {
-    expect(canBeJongsung('ㄱ')).toBe(true);
+  describe('종성이 될 수 있다고 판단되는 경우', () => {
+    it('ㄱ', () => {
+      expect(canBeJongsung('ㄱ')).toBe(true);
+    });
+    it('ㄱㅅ', () => {
+      expect(canBeJongsung('ㄱㅅ')).toBe(true);
+    });
+    it('ㅂㅅ', () => {
+      expect(canBeJongsung('ㅂㅅ')).toBe(true);
+    });
   });
-  it('ㄱㅅ', () => {
-    expect(canBeJongsung('ㄱㅅ')).toBe(true);
-  });
-  it('ㅂㅅ', () => {
-    expect(canBeJongsung('ㅂㅅ')).toBe(true);
-  });
-  it('ㅎㄹ', () => {
-    expect(canBeJongsung('ㅎㄹ')).toBe(false);
-  });
-  it('ㅗㅏ', () => {
-    expect(canBeJongsung('ㅗㅏ')).toBe(false);
-  });
-  it('ㅏ', () => {
-    expect(canBeJongsung('ㅏ')).toBe(false);
-  });
-  it('가', () => {
-    expect(canBeJongsung('ㅏ')).toBe(false);
+
+  describe('종성이 될 수 없다고 판단되는 경우', () => {
+    it('ㅎㄹ', () => {
+      expect(canBeJongsung('ㅎㄹ')).toBe(false);
+    });
+    it('ㅗㅏ', () => {
+      expect(canBeJongsung('ㅗㅏ')).toBe(false);
+    });
+    it('ㅏ', () => {
+      expect(canBeJongsung('ㅏ')).toBe(false);
+    });
+    it('가', () => {
+      expect(canBeJongsung('ㅏ')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Overview
[Issue] 테스트코드 리팩터링 #79
- 테스트코드의 관심사에 따라 describe를 그룹화 하였습니다.

### Previous Code
```ts

describe('chosungIncludes', () => {
  it('should return true when "ㅍㄹㅌ" is entered for searching "프론트엔드"', () => {
    expect(chosungIncludes('프론트엔드', 'ㅍㄹㅌ')).toBe(true);
  });

  it('should return true when "ㅍㄹㅌ" is entered for searching "00프론트엔드"', () => {
    expect(chosungIncludes('00프론트엔드', 'ㅍㄹㅌ')).toBe(true);
  });

  it('should return false when "ㅍㅌ" is entered for searching "프론트엔드"', () => {
    expect(chosungIncludes('프론트엔드', 'ㅍㅌ')).toBe(false);
  });

  it('should return true when "ㅍㄹㅌㅇㄷㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
    expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷㄱㅂㅈ')).toBe(true);
  });

  // ...codes
});
```

### Refactored Code
```ts
import { chosungIncludes } from './chosungIncludes';

describe('chosungIncludes', () => {
  describe('초성이 포함되어있다고 판단되는 경우', () => {
    it('should return true when "ㅍㄹㅌ" is entered for searching "프론트엔드"', () => {
      expect(chosungIncludes('프론트엔드', 'ㅍㄹㅌ')).toBe(true);
    });

    it('should return true when "ㅍㄹㅌ" is entered for searching "00프론트엔드"', () => {
      expect(chosungIncludes('00프론트엔드', 'ㅍㄹㅌ')).toBe(true);
    });

    it('should return true when "ㅍㄹㅌㅇㄷㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
      expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷㄱㅂㅈ')).toBe(true);
    });

    it('should return true when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching "프론트엔드 개발자"', () => {
      expect(chosungIncludes('프론트엔드 개발자', 'ㅍㄹㅌㅇㄷ ㄱㅂㅈ')).toBe(true);
    });
  });

  describe('초성이 포함되어있다고 판단되지 않는 경우', () => {
    it('should return false when "ㅍㅌ" is entered for searching "프론트엔드"', () => {
      expect(chosungIncludes('프론트엔드', 'ㅍㅌ')).toBe(false);
    });

    it('should return false when "ㅍㄹㅌㅇㄷ ㄱㅂㅈ" is entered for searching " "', () => {
      expect(chosungIncludes('프론트엔드 개발자', ' ')).toBe(false);
    });

    // ...codes
  });
});
```

---

### hasSingleBatchim
`홑받침이 맞다고 판단되는 경우`는 기존 test description과 겹쳐 오히려 가독성을 저해할 수 있다고 판단하여 추가하지 않았습니다.

```ts
describe('hasSingleBatchim', () => {
  it('홑받침을 받으면 true를 반환한다.', () => { // ⛳️ describe를 추가하지 않음.
    expect(hasSingleBatchim('공')).toBe(true);
    expect(hasSingleBatchim('핫')).toBe(true);
    expect(hasSingleBatchim('양')).toBe(true);
    expect(hasSingleBatchim('신')).toBe(true);
  });

  describe('홑받침이 아니라고 판단되는 경우', () => {
    it('겹받침을 받으면 false를 반환한다.', () => {
      expect(hasSingleBatchim('값')).toBe(false);
      expect(hasSingleBatchim('읊')).toBe(false);
    });

    it('받침이 없는 문자를 받으면 false를 반환한다.', () => {
      expect(hasSingleBatchim('토')).toBe(false);
      expect(hasSingleBatchim('서')).toBe(false);
    });
  });
});
```


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
