### PR TITLE
fix: 호환성 개선을 위해 배열의 마지막 요소 가져오는 부분 수정

### DIFF
--- a/src/_internal/index.ts
+++ b/src/_internal/index.ts
@@ -1,5 +1,5 @@
 export function excludeLastElement(array: string[]): [string[], string] {
-  const lastElement = array.at(-1);
+  const lastElement = array[array.length - 1];
   return [array.slice(0, -1), lastElement ?? ''];
 }
 


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

기존 excludeLastElement에서 배열의 마지막 요소를 `const lastElement = array.at(-1);` 과 같이 가져왔는데, 구형 브라우저나 런타임에서 Array.at()이 지원되지 않을 가능성이 있기 때문에 호환성 개선을 위해 배열의 마지막 요소를 가져오는 부분을 다음과 같이 수정하였습니다.

```js
export function excludeLastElement(array: string[]): [string[], string] {
  const lastElement = array[array.length - 1]; // fixed
  return [array.slice(0, -1), lastElement ?? ''];
}
```


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
