### PR TITLE
ci(package.json): lint by publint

### DIFF
--- a/.changeset/large-keys-lick.md
+++ b/.changeset/large-keys-lick.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+ci(package.json): lint by publint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,18 @@ jobs:
       - run:
           name: Check Peer Dependency
           command: ./.scripts/check-peer.sh || (echo "Peer Dependency 오류가 발생했습니다."; exit -1)
+  publint:
+    docker:
+      - image: cimg/node:20.12
+    steps:
+      - checkout
+      - setup
+      - run:
+          name: Build
+          command: yarn build
+      - run:
+          name: Check Publint
+          command: yarn publint
 
   test:
     docker:
@@ -75,7 +87,7 @@ jobs:
           name: vitest
           command: yarn vitest --reporter=junit > ./.junit
           environment:
-            YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+            YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
       - store_test_results:
           path: ./.junit
       - store_artifacts:
@@ -98,6 +110,10 @@ workflows:
             branches:
               ignore: main
       - check-peer:
+          filters:
+            branches:
+              ignore: main
+      - publint:
           filters:
             branches:
               ignore: main

--- a/package.json
+++ b/package.json
@@ -17,15 +17,23 @@
   "repository": "github:toss/es-hangul",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
+  "type": "commonjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist/*"
   ],
@@ -38,6 +46,7 @@
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version",
     "packlint": "packlint sort -R",
+    "publint": "publint --strict",
     "test": "vitest run --coverage --typecheck",
     "test:watch": "vitest --ui --coverage --typecheck",
     "typecheck": "tsc --noEmit"
@@ -55,23 +64,13 @@
     "eslint-config-prettier": "^8.5.0",
     "packlint": "^0.2.4",
     "prettier": "^3.2.5",
+    "publint": "^0.2.7",
     "tsup": "^8.0.2",
     "typescript": "^5.4.3",
     "vitest": "^1.5.0"
   },
   "publishConfig": {
-    "access": "public",
-    "main": "./dist/index.js",
-    "module": "./dist/index.mjs",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "import": "./dist/index.mjs",
-        "types": "./dist/index.d.ts"
-      },
-      "./package.json": "./package.json"
-    },
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs"
-  }
+    "access": "public"
+  },
+  "import": "./dist/index.mjs"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3907,6 +3907,7 @@ __metadata:
     eslint-config-prettier: "npm:^8.5.0"
     packlint: "npm:^0.2.4"
     prettier: "npm:^3.2.5"
+    publint: "npm:^0.2.7"
     tsup: "npm:^8.0.2"
     typescript: "npm:^5.4.3"
     vitest: "npm:^1.5.0"
@@ -5142,6 +5143,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^8.0.1":
+  version: 8.1.0
+  resolution: "glob@npm:8.1.0"
+  dependencies:
+    fs.realpath: "npm:^1.0.0"
+    inflight: "npm:^1.0.4"
+    inherits: "npm:2"
+    minimatch: "npm:^5.0.1"
+    once: "npm:^1.3.0"
+  checksum: 10c0/cb0b5cab17a59c57299376abe5646c7070f8acb89df5595b492dba3bfb43d301a46c01e5695f01154e6553168207cb60d4eaf07d3be4bc3eb9b0457c5c561d0f
+  languageName: node
+  linkType: hard
+
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -5563,6 +5577,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3"
   checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
+"ignore-walk@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ignore-walk@npm:5.0.1"
+  dependencies:
+    minimatch: "npm:^5.0.1"
+  checksum: 10c0/0d157a54d6d11af0c3059fdc7679eef3b074e9a663d110a76c72788e2fb5b22087e08b21ab767718187ac3396aca4d0aa6c6473f925b19a74d9a00480ca7a76e
   languageName: node
   linkType: hard
 
@@ -7520,6 +7543,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^5.0.1":
+  version: 5.1.6
+  resolution: "minimatch@npm:5.1.6"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.1":
   version: 9.0.4
   resolution: "minimatch@npm:9.0.4"
@@ -7966,6 +7998,36 @@ __metadata:
   version: 0.1.2
   resolution: "normalize-range@npm:0.1.2"
   checksum: 10c0/bf39b73a63e0a42ad1a48c2bd1bda5a07ede64a7e2567307a407674e595bcff0fa0d57e8e5f1e7fa5e91000797c7615e13613227aaaa4d6d6e87f5bd5cc95de6
+  languageName: node
+  linkType: hard
+
+"npm-bundled@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "npm-bundled@npm:2.0.1"
+  dependencies:
+    npm-normalize-package-bin: "npm:^2.0.0"
+  checksum: 10c0/5b2dc1de455d38200e49c6205dee185ce919ea6b608672c693bec8907116bc5686dabcc150347630d351c1c533315fd60a1910ce00bdad6bb204cef016b90b7d
+  languageName: node
+  linkType: hard
+
+"npm-normalize-package-bin@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "npm-normalize-package-bin@npm:2.0.0"
+  checksum: 10c0/9b5283a2e423124c60fbc14244d36686b59e517d29156eacf9df8d3dc5d5bf4d9444b7669c607567ed2e089bbdbef5a2b3678cbf567284eeff3612da6939514b
+  languageName: node
+  linkType: hard
+
+"npm-packlist@npm:^5.1.3":
+  version: 5.1.3
+  resolution: "npm-packlist@npm:5.1.3"
+  dependencies:
+    glob: "npm:^8.0.1"
+    ignore-walk: "npm:^5.0.1"
+    npm-bundled: "npm:^2.0.0"
+    npm-normalize-package-bin: "npm:^2.0.0"
+  bin:
+    npm-packlist: bin/index.js
+  checksum: 10c0/a8bea97661b2a7132bc8832d5560da24f823ee5324429bd16eb82b7873557de14641bc3fed8a7611b0d88b9771e59e99e01a9e551a53adb164327ded6128aada
   languageName: node
   linkType: hard
 
@@ -8689,6 +8751,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"publint@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "publint@npm:0.2.7"
+  dependencies:
+    npm-packlist: "npm:^5.1.3"
+    picocolors: "npm:^1.0.0"
+    sade: "npm:^1.8.1"
+  bin:
+    publint: lib/cli.js
+  checksum: 10c0/dfa476c77c2644de6986ef94616780cc44398bbfe6f56a790aadbfa0ec9d41a136c8a0c5a0a999ceb8bcee0d5736c3e93a5f28662c515c47ad6eba03244edea0
+  languageName: node
+  linkType: hard
+
 "punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -9180,7 +9255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sade@npm:^1.7.3":
+"sade@npm:^1.7.3, sade@npm:^1.8.1":
   version: 1.8.1
   resolution: "sade@npm:1.8.1"
   dependencies:


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

publishConfig의 불필요한 필드를 제거합니다
publint를 통해 package.json lint를 합니다

publint는 https://publint.dev/ 패키지가 잘 퍼블리싱되고 있는지 린팅하는 툴입니다.
1. 웹사이트에서 배포된 패키지의 package.json이 잘 정의되어있는지 체크합니다.
2. cli로 ci에 사용해 안정성을 높일 수 있습니다.
3. TanStack Query 등 사용량이 많은 패키지들에서 안정성을 위해서 사용하고 있습니다.

### AS-IS
아래 publint에서 제공되는 링크로 es-hangul@1.3.3의 package.json의 제안사항을 확인할 수도 있습니다
https://publint.dev/es-hangul@1.3.3

![image](https://github.com/toss/es-hangul/assets/61593290/e3140cb8-4d77-453d-a6aa-7eb814341aab)

### TO-BE
- publint cli(`yarn publint`)로도 확인할 수 있게 스크립트 필드에 추가했습니다. 이를 활용해 ci에서도 항상 체크됩니다.
- publint로 체크
  - type필드 누락
  - publintConfig필드의 불필요한 필드
  - exports필드에서 import, require시 바라볼 타입스크립트 파일을 각각 index.d.mts, index.d.ts로 지정되도록 변경
- 앞으로도 build 설정 파일(tsup)의 변경으로 달라질 때 publint가 ci에서 배포전에 잡아주게 됩니다

### 참고
- https://github.com/TanStack/query/pull/5528
- https://github.com/TanStack/query/blob/main/package.json#L73

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
4. I have written documents and tests, if needed.
