### PR TITLE
feat: es-hangul을 사용하는 회사, 프로젝트 들의 로고를 나열할 수 있는 컴포넌트를 만듭니다.

### DIFF
--- a/docs/src/components/introduction/AdoptorImage.tsx
+++ b/docs/src/components/introduction/AdoptorImage.tsx
@@ -1,0 +1,20 @@
+import { useIsDarkMode } from '@/hooks/use-is-dark-mode';
+import { ImgHTMLAttributes } from 'react';
+
+interface Props extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> {
+  lightSrc: string;
+  darkSrc: string;
+}
+
+export function AdoptorImage(props: Props) {
+  const isDarkMode = useIsDarkMode();
+  return (
+    <img
+      src={isDarkMode ? props.darkSrc : props.lightSrc}
+      {...props}
+      style={{
+        height: 80,
+      }}
+    />
+  );
+}

--- a/docs/src/pages/docs/introduction.constatns.ts
+++ b/docs/src/pages/docs/introduction.constatns.ts
@@ -1,0 +1,9 @@
+export const adopters = [
+  {
+    name: '비바리퍼블리카',
+    image: {
+      light: 'https://framerusercontent.com/images/jxEU2PdB9CSg4OmJvPsKf4bwBA.png?scale-down-to=512',
+      dark: 'https://framerusercontent.com/images/9DjROJdBAEConeKkYzErikQ2GGo.png?scale-down-to=512',
+    },
+  },
+];

--- a/docs/src/pages/docs/introduction.en.mdx
+++ b/docs/src/pages/docs/introduction.en.mdx
@@ -1,4 +1,6 @@
 import { Steps, Callout } from 'nextra/components';
+import { AdoptorImage } from '@/components/introduction/AdoptorImage';
+import { adopters } from './introduction.constatns.ts'
 
 # Introduction to es-hangul
 
@@ -71,6 +73,24 @@ const word2 = '바나나';
 const sentence2 = josa(word2, '이/가') + ' 맛있습니다.';
 console.log(sentence2); // '바나나가 맛있습니다.'
 ```
+
+
+#### Who's using es-hangul? 
+<br/>
+
+<div style={{
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '1rem',
+  justifyContent: 'center'
+}}>
+{
+
+  adopters.map((adopter) => {
+    return <AdoptorImage lightSrc={adopter.image.light} darkSrc={adopter.image.dark} alt={adopter.name}/>    
+  })
+}
+</div>
 
 <Callout type="info">
 

--- a/docs/src/pages/docs/introduction.ko.mdx
+++ b/docs/src/pages/docs/introduction.ko.mdx
@@ -1,5 +1,11 @@
 import { Steps, Callout } from 'nextra/components';
+import { adopters } from './introduction.constatns.ts'
+import { AdoptorImage } from '@/components/introduction/AdoptorImage'
 
+const theme = useTheme();
+console.log(theme);
+    const isDarkMode = useIsDarkMode();
+    console.log(isDarkMode);
 # es-hangul 소개
 
 [![npm version](https://img.shields.io/npm/v/es-hangul?color=000&labelColor=000&logo=npm&label=)](https://www.npmjs.com/package/es-hangul)
@@ -73,6 +79,23 @@ const word2 = '바나나';
 const sentence2 = josa(word2, '이/가') + ' 맛있습니다.';
 console.log(sentence2); // '바나나가 맛있습니다.'
 ```
+
+#### es-hangul을 사용중인 곳
+<br/>
+
+<div style={{
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '1rem',
+  justifyContent: 'center'
+}}>
+{
+
+  adopters.map((adopter) => {
+    return <AdoptorImage lightSrc={adopter.image.light} darkSrc={adopter.image.dark} alt={adopter.name}/>    
+  })
+}
+</div>
 
 <Callout type="info">
 

--- a/docs/src/pages/docs/introduction.ko.mdx
+++ b/docs/src/pages/docs/introduction.ko.mdx
@@ -2,10 +2,6 @@ import { Steps, Callout } from 'nextra/components';
 import { adopters } from './introduction.constatns.ts'
 import { AdoptorImage } from '@/components/introduction/AdoptorImage'
 
-const theme = useTheme();
-console.log(theme);
-    const isDarkMode = useIsDarkMode();
-    console.log(isDarkMode);
 # es-hangul 소개
 
 [![npm version](https://img.shields.io/npm/v/es-hangul?color=000&labelColor=000&logo=npm&label=)](https://www.npmjs.com/package/es-hangul)


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

#97 에서 @manudeli 님이 제안주신것처럼, 라이브러리의 신뢰성 및 브랜딩을 높이기 위한 작업입니다.

많은 분들이 직접 PR로 배열을 관리하는 방향을 생각하고 있어요.


| 한글 | 영어 |
| --------- | ----------- |
| <img width="1611" alt="image" src="https://github.com/toss/es-hangul/assets/69495129/4445f164-9d5e-40fe-a6d6-737bac674c55"> | <img width="1479" alt="image" src="https://github.com/toss/es-hangul/assets/69495129/d5844a32-dc17-4c65-acf1-e183ce0911f9"> |

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
