### PR TITLE
docs: 1kb 문구 제거

### DIFF
--- a/docs/src/pages/docs/introduction.en.mdx
+++ b/docs/src/pages/docs/introduction.en.mdx
@@ -15,7 +15,9 @@ When developing products that handle Hangul, tasks such as initial consonant sea
 
 ### Lightweight and Tree-shakable
 
-By using ECMAScript Modules, you can include only the functions you use in your application. For example, if you use the `josa` function, only the related logic is included in the application. Additionally, by providing the minimum necessary code for handling Hangul, you can reduce the size of the JavaScript downloaded by users. (The entire library is about 1KB when compressed with Gzip.) [![es-hangul's badge](https://deno.bundlejs.com/?q=es-hangul&badge=detailed)](https://bundlejs.com/?q=es-hangul)
+By using ECMAScript Modules, you can include only the functions you use in your application. For example, if you use the `josa` function, only the related logic is included in the application.
+Additionally, by providing the minimum necessary code for handling Hangul, you can reduce the size of the JavaScript downloaded by users.
+[![es-hangul's bundle size](https://deno.bundlejs.com/?q=es-hangul&badge=detailed)](https://bundlejs.com/?q=es-hangul)
 
 ### Battle-tested
 

--- a/docs/src/pages/docs/introduction.ko.mdx
+++ b/docs/src/pages/docs/introduction.ko.mdx
@@ -17,8 +17,8 @@ import { Adopters } from '@/components/introduction/Adopters';
 ### 가볍습니다 (Tree-shakable)
 
 ECMAScript Modules를 이용하여 사용하는 함수만 애플리케이션에 포함할 수 있습니다. 예를 들어, [`josa`](./api/josa) 함수를 사용하는 경우, 해당 함수와 연관된 로직만 애플리케이션에 포함됩니다.
-또한 한글을 다루는 데에 필요한 최소한의 코드를 제공함으로써, 사용자가 내려받는 JavaScript의 크기를 줄일 수 있습니다. (전체 라이브러리가 Gzip 압축 기준 1KB 정도입니다.)
-[![es-hangul's badge](https://deno.bundlejs.com/?q=es-hangul&badge=detailed)](https://bundlejs.com/?q=es-hangul)
+또한 한글을 다루는 데에 필요한 최소한의 코드를 제공함으로써, 사용자가 내려받는 JavaScript의 크기를 줄일 수 있습니다.
+[![es-hangul's bundle size](https://deno.bundlejs.com/?q=es-hangul&badge=detailed)](https://bundlejs.com/?q=es-hangul)
 
 ### 신뢰할 수 있습니다
 


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

<img width="870" alt="image" src="https://github.com/toss/es-hangul/assets/61593290/c09b76c6-87d5-4fc5-9b2b-2da0da84aa5e">

더 이상 gzip사이즈가 1kb가 아니어서 문구를 제거합니다. [![es-hangul's bundle size](https://deno.bundlejs.com/?q=es-hangul&badge=detailed)](https://bundlejs.com/?q=es-hangul)
제거해도 아래 자동으로 트래킹되는 뱃지가 있어서 번들이 작다는 메시지는 충분히 전달될 것으로 기대하고 있습니다



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
