### PR TITLE
test: utils의 테스트 케이스를 보강하여 uncovered line을 개선합니다

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -30,6 +30,9 @@ describe('hasBatchim', () => {
     it('"서" 문자에서 받침이 없으므로 false를 반환한다.', () => {
       expect(hasBatchim('서')).toBe(false);
     });
+    it('빈 문자열은 받침이 없으므로 false를 반환한다.', () => {
+      expect(hasBatchim('')).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
## Overview

`src/utils.spec.ts`의 `hasBatchim`함수의 테스트 케이스를 보강하였습니다.

AS-IS
<img width="741" alt="image" src="https://github.com/toss/es-hangul/assets/55759551/82f22b26-26b8-4784-a2fb-3d666df942fc">

TO-BE
<img width="736" alt="image" src="https://github.com/toss/es-hangul/assets/55759551/00e46dd2-3282-434f-ae4a-15343af9da8b">


## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
