### PR TITLE
fix: Adopters 컴포넌트를 수정합니다

### DIFF
--- a/docs/src/components/introduction/Adopters.tsx
+++ b/docs/src/components/introduction/Adopters.tsx
@@ -32,8 +32,8 @@ export const Adopters = () => {
 
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2rem', justifyContent: 'center' }}>
-      {adopterLogoImagePropsList.map(props => (
-        <Image key={props.src} {...props} src={isDarkMode ? props.darkSrc : props.src} />
+      {adopterLogoImagePropsList.map(({ darkSrc, src, alt, ...props }) => (
+        <Image key={src} src={isDarkMode ? darkSrc : src} alt={alt} {...props} />
       ))}
     </div>
   );

--- a/docs/src/components/introduction/Adopters.tsx
+++ b/docs/src/components/introduction/Adopters.tsx
@@ -31,7 +31,7 @@ export const Adopters = () => {
   const isDarkMode = useIsDarkMode();
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '2rem', justifyContent: 'center' }}>
+    <div className="flex flex-wrap gap-8 justify-center">
       {adopterLogoImagePropsList.map(({ darkSrc, src, alt, ...props }) => (
         <Image key={src} src={isDarkMode ? darkSrc : src} alt={alt} {...props} />
       ))}


### PR DESCRIPTION
## Overview

1. Adopters 컴포넌트의 div 태그의 스타일 작성법을 다른 컴포넌트들과 동일하게 tailwindcss로 변경하였습니다
2. Image 태그에 올바르지 않게 적용된 props를 수정하였습니다.

**Image 태그에 DOM element가 지원하지 않는 darkSrc 속성이 적용됨.**

![image](https://github.com/toss/es-hangul/assets/55759551/b1d75917-4593-4285-864b-6307041b8076)
<img width="442" alt="image" src="https://github.com/toss/es-hangul/assets/55759551/443d33eb-6771-473b-9f85-44a9c72a92b1">


**eslint rule 중 하나인 [jsx-a11y/alt-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/1be7b709eececd83f1d5f67a60b2c97cfe9a561d/docs/rules/alt-text.md)로 인해 `alt` prop을 컴포넌트에 명시해야 함.**

alt 값을 굳이 명시하고 싶지 않다면 eslint rule 설정을 변경하는 것도 선택지 중 하나인 것 같습니다.

![image](https://github.com/toss/es-hangul/assets/55759551/ade8abe3-23cf-4864-8bf2-4bc36c1c5032)

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
4. I have written documents and tests, if needed.
