### PR TITLE
test : removeLastHangulCharacter 에 대한 테스트 추가

### DIFF
--- a/src/removeLastHangulCharacter.spec.ts
+++ b/src/removeLastHangulCharacter.spec.ts
@@ -11,6 +11,11 @@ describe('removeLastHangulCharacter', () => {
     expect(removeLastHangulCharacter('일요일')).toBe('일요이');
     expect(removeLastHangulCharacter('깎')).toBe('까');
   });
+  it('마지막 문자가 초성과 중성의 조합으로 끝나며, 중성 입력 시 국제 표준 한글 레이아웃 기준 단일키로 처리되지 않는 이중모음 (ㅗ/ㅜ/ㅡ 계 이중모음) 인 경우 초성과 중성의 시작 모음만 남긴다.', () => {
+    expect(removeLastHangulCharacter('데자와')).toBe('데자오');
+    expect(removeLastHangulCharacter('예의')).toBe('예으');
+    expect(removeLastHangulCharacter("예예")).toBe('예ㅇ');
+  });
   it('빈 문자열일 경우 빈 문자열을 반환한다.', () => {
     expect(removeLastHangulCharacter('')).toBe('');
   });

--- a/src/removeLastHangulCharacter.spec.ts
+++ b/src/removeLastHangulCharacter.spec.ts
@@ -12,9 +12,9 @@ describe('removeLastHangulCharacter', () => {
     expect(removeLastHangulCharacter('깎')).toBe('까');
   });
   it('마지막 문자가 초성과 중성의 조합으로 끝나며, 중성 입력 시 국제 표준 한글 레이아웃 기준 단일키로 처리되지 않는 이중모음 (ㅗ/ㅜ/ㅡ 계 이중모음) 인 경우 초성과 중성의 시작 모음만 남긴다.', () => {
-    expect(removeLastHangulCharacter('데자와')).toBe('데자오');
+    expect(removeLastHangulCharacter('전화')).toBe('전호');
     expect(removeLastHangulCharacter('예의')).toBe('예으');
-    expect(removeLastHangulCharacter("예예")).toBe('예ㅇ');
+    expect(removeLastHangulCharacter("신세계")).toBe('신세ㄱ'); // 'ㅖ'의 경우 단일키 처리가 가능한 이중모음이므로 모음이 남지 않는다.
   });
   it('빈 문자열일 경우 빈 문자열을 반환한다.', () => {
     expect(removeLastHangulCharacter('')).toBe('');

--- a/src/removeLastHangulCharacter.ts
+++ b/src/removeLastHangulCharacter.ts
@@ -16,6 +16,8 @@ import { excludeLastElement } from './_internal';
  * removeLastHangulCharacter('안녕하세요 값') // 안녕하세요 갑
  * removeLastHangulCharacter('프론트엔드') // 프론트엔ㄷ
  * removeLastHangulCharacter('일요일') // 일요이
+ * removeLastHangulCharacter('전화') // 전호
+ * removeLastHangulCharacter('신세계') // 신세ㄱ
  */
 export function removeLastHangulCharacter(words: string) {
   const disassembledGroups = disassembleHangulToGroups(words);


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

### 이중모음에 대한 테스트 추가
`removeLastHangulCharacter()` 사용 시 마지막 문자가 받침 없이 이중모음으로 끝나는 경우에 대한 테스트를 추가했으며, 해당 함수의 `@example` 내역에 이중모음에 대한 예시를 함께 추가했습니다.

`ISO/IEC 9555`를 기반으로 제정된 [국가 표준 키보드 한글 레이아웃](https://standard.go.kr/streamdocs/view/sd;streamdocsId=72059311543363201)에서는 `'ㅗ', 'ㅜ', 'ㅡ'` 에 대한 이중모음에 대해 2회 입력을 지정합니다.
```text
ex ) 'ㅘ', 'ㅙ', 'ㅚ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅢ'
```

예를들어, `'전화'`의 `'ㅘ'`는 `'ㅗ', 'ㅏ'` 로 2회 입력이 이루어지는 이중모음이므로 `removeLastHangulCharacter('전화')` 시, `'전호'` 가 반환되어야 합니다.

</br>

한편, 이중모음 중 [국가 표준 키보드 한글 레이아웃](https://standard.go.kr/streamdocs/view/sd;streamdocsId=72059311543363201) 에서 단일키 입력을 허용하는 모음들이 있습니다. 대표적으로 `'ㅐ', 'ㅔ'` 와 `shift` 를 활용한 `'ㅒ', 'ㅖ'` 가 있습니다. 

> 해당 이중모음이 단일키 입력이 가능한 이유는, 자주 사용하는 이중 모음이기 때문이라 합니다.

예를들어, `'신세계'`의 `'ㅖ'`는 단일키 입력이 가능한 이중모음이므로 `removeLastHangulCharacter('신세계')` 시, `'신세ㄱ'` 가 반환되어야 합니다.


## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
