### PR TITLE
feat: 숫자로 된 금액을 국립국어원 규칙의 한글 읽기로 변환합니다.

### DIFF
--- a/docs/src/pages/docs/api/amountsToHangul.en.md
+++ b/docs/src/pages/docs/api/amountsToHangul.en.md
@@ -1,0 +1,24 @@
+---
+title: amountsToHangul
+---
+
+# amountsToHangul
+
+Converts numeric amounts to the Korean reading of the [National Institute of Korean Language](https://ko.dict.naver.com/#/correct/korean/info?seq=602) rules.
+
+For detailed examples, see below.
+
+```typescript
+function amountsToHangul(
+  // A string of numeric amounts
+  str: string
+): string;
+```
+
+## Examples
+
+```tsx
+amountsToHangul('15,201,100'); // '일천오백이십만천백';
+amountsToHangul('120,030원'); // '일십이만삼십' - Ignore non-numeric characters
+amountsToHangul('392.24'); // '삼백구십이' - Ignore decimals
+```

--- a/docs/src/pages/docs/api/amountsToHangul.ko.md
+++ b/docs/src/pages/docs/api/amountsToHangul.ko.md
@@ -1,0 +1,24 @@
+---
+title: amountsToHangul
+---
+
+# amountsToHangul
+
+숫자로 된 금액을 [국립국어원](https://ko.dict.naver.com/#/correct/korean/info?seq=602) 규칙의 한글 읽기로 변환합니다.
+
+자세한 예시는 아래 Example을 참고하세요.
+
+```typescript
+function amountsToHangul(
+  // 숫자로 된 금액 문자열
+  str: string
+): string;
+```
+
+## Examples
+
+```tsx
+amountsToHangul('15,201,100'); // '일천오백이십만천백';
+amountsToHangul('120,030원'); // '일십이만삼십' - 숫자 외 문자 무시
+amountsToHangul('392.24'); // '삼백구십이' - 소수점 무시
+```

--- a/src/amountsToHangul.spec.ts
+++ b/src/amountsToHangul.spec.ts
@@ -1,0 +1,9 @@
+import { amountsToHangul } from './amountsToHangul';
+
+describe('amountsToHangul', () => {
+  it('숫자로 된 금액을 한글로 표기', () => {
+    expect(amountsToHangul('15,201,100')).toEqual('일천오백이십만천백');
+    expect(amountsToHangul('120,030원')).toEqual('일십이만삼십'); // 숫자 외 문자 무시
+    expect(amountsToHangul('392.24')).toEqual('삼백구십이'); // 소수점 무시
+  });
+});

--- a/src/amountsToHangul.ts
+++ b/src/amountsToHangul.ts
@@ -1,0 +1,28 @@
+export const HANGUL_DIGITS = ['', '만', '억', '조', '경', '해', '자', '양', '구', '간', '정', '재', '극', '항하사', '아승기', '나유타', '불가사의', '무량대수', '겁', '업'];
+export const HANGUL_NUMBERS = ['', '일', '이', '삼', '사', '오', '육', '칠', '팔', '구'];
+export const HANGUL_CARDINAL = ['', '십', '백', '천'];
+
+// https://ko.dict.naver.com/#/correct/korean/info?seq=602
+// https://github.com/crucifyer/koreanCardinalOrdinal
+export function amountsToHangul(str: string) {
+  str = str.replace(/\..*$/, '') // 소수점 지원 안함
+    .replace(/[^\d]+/g, ''); // , 표기 등 오류내지 않음
+  if(str.length > 80) {
+    return undefined;
+  }
+  const result = [];
+  for(let i = 0; i < str.length - 1; i ++) {
+    const d = str.length - i - 1;
+    if(str[i] > '1' || d % 4 === 0 || i === 0) {
+      result.push(HANGUL_NUMBERS[parseInt(str[i])]);
+    }
+    if(d % 4 === 0) {
+      result.push(HANGUL_DIGITS[d / 4]);
+    }
+    if(str[i] !== '0') {
+      result.push(HANGUL_CARDINAL[d % 4]);
+    }
+  }
+  result.push(HANGUL_NUMBERS[parseInt(str[str.length - 1])]);
+  return result.join('');
+}

--- a/src/chosungIncludes.ts
+++ b/src/chosungIncludes.ts
@@ -2,13 +2,13 @@ import { disassembleHangulToGroups } from './disassemble';
 import { canBeChosung, getChosung } from './utils';
 
 export function chosungIncludes(x: string, y: string) {
-  const trimmedY = y.replace(/\s/g, '');
+  const trimmedY = y.replace(/\s+/g, '');
 
   if (!isOnlyChosung(trimmedY)) {
     return false;
   }
 
-  const chosungX = getChosung(x).replace(/\s/g, '');
+  const chosungX = getChosung(x).replace(/\s+/g, '');
   const chosungY = trimmedY;
 
   return chosungX.includes(chosungY);

--- a/src/removeLastHangulCharacter.ts
+++ b/src/removeLastHangulCharacter.ts
@@ -19,7 +19,7 @@ import { excludeLastElement } from './_internal';
  */
 export function removeLastHangulCharacter(words: string) {
   const disassembledGroups = disassembleHangulToGroups(words);
-  const lastCharacter = disassembledGroups.at(-1);
+  const lastCharacter = disassembledGroups[disassembledGroups.length - 1];
 
   if (lastCharacter == null) {
     return '';

--- a/src/removeLastHangulCharacter.ts
+++ b/src/removeLastHangulCharacter.ts
@@ -1,6 +1,7 @@
 import { combineHangulCharacter } from './combineHangulCharacter';
 import { disassembleHangulToGroups } from './disassemble';
 import { excludeLastElement } from './_internal';
+// import { disassembleCompleteHangulCharacter } from './disassembleCompleteHangulCharacter';
 
 /**
  * @name removeLastHangulCharacter
@@ -18,25 +19,13 @@ import { excludeLastElement } from './_internal';
  * removeLastHangulCharacter('일요일') // 일요이
  */
 export function removeLastHangulCharacter(words: string) {
-  const disassembledGroups = disassembleHangulToGroups(words);
-  const lastCharacter = disassembledGroups[disassembledGroups.length - 1];
-
+  const lastCharacter = words[words.length - 1];
   if (lastCharacter == null) {
     return '';
   }
-
-  const withoutLastCharacter = disassembledGroups
-    .filter(v => v !== lastCharacter)
-    .map(([first, middle, last]) => {
-      if (middle != null) {
-        return combineHangulCharacter(first, middle, last);
-      }
-
-      return first;
-    });
-
-  const [[first, middle, last]] = excludeLastElement(lastCharacter);
+  const disassembleLastCharacter = disassembleHangulToGroups(lastCharacter);
+  const [[first, middle, last]] = excludeLastElement(disassembleLastCharacter[0]);
   const result = middle != null ? combineHangulCharacter(first, middle, last) : first;
 
-  return [...withoutLastCharacter, result].join('');
+  return [words.substring(0, words.length - 1), result].join('');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,13 @@
 import {
+  COMPLETE_HANGUL_START_CHARCODE,
+  COMPLETE_HANGUL_END_CHARCODE,
   HANGUL_CHARACTERS_BY_FIRST_INDEX,
   HANGUL_CHARACTERS_BY_LAST_INDEX,
   HANGUL_CHARACTERS_BY_MIDDLE_INDEX,
+  NUMBER_OF_JONGSUNG
 } from './constants';
 import { disassembleHangul, disassembleHangulToGroups } from './disassemble';
-import { disassembleCompleteHangulCharacter } from './disassembleCompleteHangulCharacter';
+// import { disassembleCompleteHangulCharacter } from './disassembleCompleteHangulCharacter';
 
 /**
  * @name hasBatchim
@@ -26,9 +29,14 @@ export function hasBatchim(str: string) {
   if (lastChar == null) {
     return false;
   }
+  const charCode = lastChar.charCodeAt(0);
+  const isCompleteHangul = COMPLETE_HANGUL_START_CHARCODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHARCODE;
 
-  const disassembled = disassembleCompleteHangulCharacter(lastChar);
-  return disassembled != null && disassembled.last !== '';
+  if (!isCompleteHangul) {
+    return undefined;
+  }
+
+  return (charCode - COMPLETE_HANGUL_START_CHARCODE) % NUMBER_OF_JONGSUNG > 0;
 }
 
 /**


### PR DESCRIPTION
## Overview

숫자로 된 금액을 [국립국어원](https://ko.dict.naver.com/#/correct/korean/info?seq=602) 규칙의 한글 읽기로 변환합니다.

```tsx
amountsToHangul('15,201,100'); // '일천오백이십만천백';
amountsToHangul('120,030원'); // '일십이만삼십' - 숫자 외 문자 무시
amountsToHangul('392.24'); // '삼백구십이' - 소수점 무시
```

## PR Checklist

- [v] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
