### PR TITLE
feat: 한글 문자열에 대한 검증, assert, parsing 함수를 구현합니다.

### DIFF
--- a/src/_internal/hangul.spec.ts
+++ b/src/_internal/hangul.spec.ts
@@ -3,8 +3,8 @@ import {
   binaryAssembleHangul,
   isHangulAlphabet,
   isHangulCharacter,
-  isHangulString,
-  assertHangulString,
+  isHangul,
+  assertHangul,
   parseHangul,
   safeParseHangul,
 } from './hangul';
@@ -26,15 +26,15 @@ describe('isHangul*', () => {
     expect(isHangulAlphabet('a')).toBe(false);
   });
 
-  it('isHangulString은 한글 문자열을 받으면 true를 반환한다.', () => {
-    expect(isHangulString('값')).toBe(true);
-    expect(isHangulString('ㄱ')).toBe(true);
-    expect(isHangulString('ㅏ')).toBe(true);
-    expect(isHangulString('저는 고양이를 좋아합니다')).toBe(true);
-    expect(isHangulString('a')).toBe(false);
-    expect(isHangulString(111)).toBe(false);
-    expect(isHangulString([111, 111])).toBe(false);
-    expect(isHangulString({ a: 111 })).toBe(false);
+  it('isHangul은 한글 문자열을 받으면 true를 반환한다.', () => {
+    expect(isHangul('값')).toBe(true);
+    expect(isHangul('ㄱ')).toBe(true);
+    expect(isHangul('ㅏ')).toBe(true);
+    expect(isHangul('저는 고양이를 좋아합니다')).toBe(true);
+    expect(isHangul('a')).toBe(false);
+    expect(isHangul(111)).toBe(false);
+    expect(isHangul([111, 111])).toBe(false);
+    expect(isHangul({ a: 111 })).toBe(false);
   });
 });
 
@@ -162,19 +162,19 @@ describe('binaryAssembleHangul', () => {
     expect(binaryAssembleHangul('저는 고양이를 좋아합니다', 'ㅜ')).toEqual('저는 고양이를 좋아합니다ㅜ');
   });
 
-  describe('assertHangulString', () => {
+  describe('assertHangul', () => {
     it('한글 문자열을 받으면 에러를 발생시키지 않는다.', () => {
-      expect(() => assertHangulString('ㄱ')).not.toThrow();
-      expect(() => assertHangulString('고양이')).not.toThrow();
-      expect(() => assertHangulString('저는 고양이를 좋아합니다')).not.toThrow();
-      expect(() => assertHangulString('저는 고양이를 좋아합니ㄷ')).not.toThrow();
+      expect(() => assertHangul('ㄱ')).not.toThrow();
+      expect(() => assertHangul('고양이')).not.toThrow();
+      expect(() => assertHangul('저는 고양이를 좋아합니다')).not.toThrow();
+      expect(() => assertHangul('저는 고양이를 좋아합니ㄷ')).not.toThrow();
     });
 
     it("한글 문자열이 아닌 값을 받으면 '___ is not a valid hangul string' 에러를 발생시킨다.", () => {
-      expect(() => assertHangulString('aaaaaa')).toThrowError('"aaaaaa" is not a valid hangul string');
-      expect(() => assertHangulString(111)).toThrowError('111 is not a valid hangul string');
-      expect(() => assertHangulString([111, 111])).toThrowError('[111,111] is not a valid hangul string');
-      expect(() => assertHangulString({ a: 111 })).toThrowError('{"a":111} is not a valid hangul string');
+      expect(() => assertHangul('aaaaaa')).toThrowError('"aaaaaa" is not a valid hangul string');
+      expect(() => assertHangul(111)).toThrowError('111 is not a valid hangul string');
+      expect(() => assertHangul([111, 111])).toThrowError('[111,111] is not a valid hangul string');
+      expect(() => assertHangul({ a: 111 })).toThrowError('{"a":111} is not a valid hangul string');
     });
   });
 });

--- a/src/_internal/hangul.spec.ts
+++ b/src/_internal/hangul.spec.ts
@@ -5,6 +5,8 @@ import {
   isHangulCharacter,
   isHangulString,
   assertHangulString,
+  parseHangul,
+  safeParseHangul,
 } from './hangul';
 
 describe('isHangul*', () => {
@@ -33,6 +35,40 @@ describe('isHangul*', () => {
     expect(isHangulString(111)).toBe(false);
     expect(isHangulString([111, 111])).toBe(false);
     expect(isHangulString({ a: 111 })).toBe(false);
+  });
+});
+
+describe('parse', () => {
+  it('parseHangul은 한글 문자열을 받으면 그대로 반환한다.', () => {
+    expect(parseHangul('값')).toBe('값');
+    expect(parseHangul('ㄱ')).toBe('ㄱ');
+    expect(parseHangul('ㅏ')).toBe('ㅏ');
+    expect(parseHangul('저는 고양이를 좋아합니다')).toBe('저는 고양이를 좋아합니다');
+  });
+
+  it('parseHangul은 한글 문자열이 아닌 값을 받으면 에러를 발생시킨다.', () => {
+    expect(() => parseHangul(111)).toThrowError('111 is not a valid hangul string');
+    expect(() => parseHangul([111, 111])).toThrowError('[111,111] is not a valid hangul string');
+    expect(() => parseHangul({ a: 111 })).toThrowError('{"a":111} is not a valid hangul string');
+  });
+
+  it('safeParseHangul은 한글 문자열을 받으면 성공 객체를 반환한다.', () => {
+    expect(safeParseHangul('값')).toEqual({ success: true, data: '값' });
+    expect(safeParseHangul('ㄱ')).toEqual({ success: true, data: 'ㄱ' });
+    expect(safeParseHangul('ㅏ')).toEqual({ success: true, data: 'ㅏ' });
+    expect(safeParseHangul('저는 고양이를 좋아합니다')).toEqual({ success: true, data: '저는 고양이를 좋아합니다' });
+  });
+
+  it('safeParseHangul은 한글 문자열이 아닌 값을 받으면 실패 객체를 반환한다.', () => {
+    expect(safeParseHangul(111)).toEqual({ success: false, error: Error('111 is not a valid hangul string') });
+    expect(safeParseHangul([111, 111])).toEqual({
+      success: false,
+      error: Error('[111,111] is not a valid hangul string'),
+    });
+    expect(safeParseHangul({ a: 111 })).toEqual({
+      success: false,
+      error: Error('{"a":111} is not a valid hangul string'),
+    });
   });
 });
 

--- a/src/_internal/hangul.spec.ts
+++ b/src/_internal/hangul.spec.ts
@@ -1,4 +1,11 @@
-import { binaryAssembleHangulCharacters, binaryAssembleHangul, isHangulAlphabet, isHangulCharacter } from './hangul';
+import {
+  binaryAssembleHangulCharacters,
+  binaryAssembleHangul,
+  isHangulAlphabet,
+  isHangulCharacter,
+  isHangulString,
+  assertHangulString,
+} from './hangul';
 
 describe('isHangul*', () => {
   it('isHangulCharacter는 완성된 한글 문자를 받으면 true를 반환한다.', () => {
@@ -15,6 +22,17 @@ describe('isHangul*', () => {
     expect(isHangulAlphabet('ㄱ')).toBe(true);
     expect(isHangulAlphabet('ㅏ')).toBe(true);
     expect(isHangulAlphabet('a')).toBe(false);
+  });
+
+  it('isHangulString은 한글 문자열을 받으면 true를 반환한다.', () => {
+    expect(isHangulString('값')).toBe(true);
+    expect(isHangulString('ㄱ')).toBe(true);
+    expect(isHangulString('ㅏ')).toBe(true);
+    expect(isHangulString('저는 고양이를 좋아합니다')).toBe(true);
+    expect(isHangulString('a')).toBe(false);
+    expect(isHangulString(111)).toBe(false);
+    expect(isHangulString([111, 111])).toBe(false);
+    expect(isHangulString({ a: 111 })).toBe(false);
   });
 });
 
@@ -106,5 +124,21 @@ describe('binaryAssembleHangul', () => {
   it('조합이 불가능한 모음이 입력되면 단순 Join 한다.', () => {
     expect(binaryAssembleHangul('저는 고양이를 좋아하', 'ㅏ')).toEqual('저는 고양이를 좋아하ㅏ');
     expect(binaryAssembleHangul('저는 고양이를 좋아합니다', 'ㅜ')).toEqual('저는 고양이를 좋아합니다ㅜ');
+  });
+
+  describe('assertHangulString', () => {
+    it('한글 문자열을 받으면 에러를 발생시키지 않는다.', () => {
+      expect(() => assertHangulString('ㄱ')).not.toThrow();
+      expect(() => assertHangulString('고양이')).not.toThrow();
+      expect(() => assertHangulString('저는 고양이를 좋아합니다')).not.toThrow();
+      expect(() => assertHangulString('저는 고양이를 좋아합니ㄷ')).not.toThrow();
+    });
+
+    it("한글 문자열이 아닌 값을 받으면 '___ is not a valid hangul string' 에러를 발생시킨다.", () => {
+      expect(() => assertHangulString('aaaaaa')).toThrowError('"aaaaaa" is not a valid hangul string');
+      expect(() => assertHangulString(111)).toThrowError('111 is not a valid hangul string');
+      expect(() => assertHangulString([111, 111])).toThrowError('[111,111] is not a valid hangul string');
+      expect(() => assertHangulString({ a: 111 })).toThrowError('{"a":111} is not a valid hangul string');
+    });
   });
 });

--- a/src/_internal/hangul.ts
+++ b/src/_internal/hangul.ts
@@ -20,6 +20,32 @@ export function assertHangulString(actual: unknown, message?: string): asserts a
   assert(isHangulString(actual), message || `${JSON.stringify(actual)} is not a valid hangul string`);
 }
 
+export function parseHangul(actual: unknown): string {
+  assertHangulString(actual);
+  return actual;
+}
+
+type SafeParseSuccess = {
+  success: true;
+  data: string;
+  error?: never;
+};
+
+type SafeParseError = {
+  success: false;
+  error: unknown;
+  data?: never;
+};
+
+export function safeParseHangul(actual: unknown): SafeParseSuccess | SafeParseError {
+  try {
+    const parsedHangul = parseHangul(actual);
+    return { success: true, data: parsedHangul };
+  } catch (error) {
+    return { success: false, error };
+  }
+}
+
 /**
  * @name binaryAssembleHangulAlphabets
  * @description

--- a/src/_internal/hangul.ts
+++ b/src/_internal/hangul.ts
@@ -12,6 +12,10 @@ export function isHangulAlphabet(character: string) {
   return /^[ㄱ-ㅣ]$/.test(character);
 }
 
+export function isHangulString(actual: unknown): actual is string {
+  return typeof actual === 'string' && /^[가-힣ㄱ-ㅣ\s]+$/.test(actual);
+}
+
 /**
  * @name binaryAssembleHangulAlphabets
  * @description

--- a/src/_internal/hangul.ts
+++ b/src/_internal/hangul.ts
@@ -17,7 +17,7 @@ export function isHangulString(actual: unknown): actual is string {
 }
 
 export function assertHangulString(actual: unknown, message?: string): asserts actual is string {
-  assert(isHangulString(actual), message || `${actual} is not a valid hangul string`);
+  assert(isHangulString(actual), message || `${JSON.stringify(actual)} is not a valid hangul string`);
 }
 
 /**

--- a/src/_internal/hangul.ts
+++ b/src/_internal/hangul.ts
@@ -16,6 +16,10 @@ export function isHangulString(actual: unknown): actual is string {
   return typeof actual === 'string' && /^[가-힣ㄱ-ㅣ\s]+$/.test(actual);
 }
 
+export function assertHangulString(actual: unknown, message?: string): asserts actual is string {
+  assert(isHangulString(actual), message || `${actual} is not a valid hangul string`);
+}
+
 /**
  * @name binaryAssembleHangulAlphabets
  * @description

--- a/src/_internal/hangul.ts
+++ b/src/_internal/hangul.ts
@@ -12,16 +12,16 @@ export function isHangulAlphabet(character: string) {
   return /^[ㄱ-ㅣ]$/.test(character);
 }
 
-export function isHangulString(actual: unknown): actual is string {
+export function isHangul(actual: unknown): actual is string {
   return typeof actual === 'string' && /^[가-힣ㄱ-ㅣ\s]+$/.test(actual);
 }
 
-export function assertHangulString(actual: unknown, message?: string): asserts actual is string {
-  assert(isHangulString(actual), message || `${JSON.stringify(actual)} is not a valid hangul string`);
+export function assertHangul(actual: unknown, message?: string): asserts actual is string {
+  assert(isHangul(actual), message || `${JSON.stringify(actual)} is not a valid hangul string`);
 }
 
 export function parseHangul(actual: unknown): string {
-  assertHangulString(actual);
+  assertHangul(actual);
   return actual;
 }
 


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

#106 이슈에서 제안한 "한글 문자열"만을 다루기 위한 내부 함수를 구현합니다.

한글 문자열임을 보장하기 위해 상황에 따라 검증, assert, parsing 기능을 제공합니다.

- 검증(validation): `isHangul`
- assert: `assertHangul`
- parsing: `parseHangul`, `safeParseHangul`

** "한글 문자열"에 대한 정의는 [다른 이슈](https://github.com/toss/es-hangul/issues/41#issuecomment-2062870608)를 참고해 "공백포함"인 경우를 생각했습니다.

`parsing`은 유저 입력같이 런타임 데이터를 주로 다루는 함수에서 사용될 것으로 기대합니다.

- 알수없는 입력값 string 타입을 한글 문자열로 parsing하여 사용

example)
```ts
export function hangulIncludes(x: string, y: string) {
  const parsedHangulX = safeParseHangul(x)  
  const parsedHangulY = safeParseHangul(y)

  if( !(parsedHangulX.success && parsedHangulY.success) ){
     return false
  }
  
   // 한글 문자열로 파싱 후 disassemble
  const disassembledX = disassembleHangul(parsedHangulX.data);
  const disassembledY = disassembleHangul(parsedHangulY.data);
  
  // ...
}
```


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
