### PR TITLE
Fix: 일관된 toThrowError 메서드 사용

### DIFF
--- a/src/_internal/hangul.spec.ts
+++ b/src/_internal/hangul.spec.ts
@@ -113,27 +113,19 @@ describe('binaryAssembleHangulCharacters', () => {
   });
 
   it('소스가 두 글자 이상이라면 Invalid source 에러를 발생시킨다.', () => {
-    assert.throws(
-      () => binaryAssembleHangulCharacters('가나', 'ㄴ'),
-      Error,
+    expect(() => binaryAssembleHangulCharacters('가나', 'ㄴ')).toThrowError(
       'Invalid source character: 가나. Source must be one character.'
     );
-    assert.throws(
-      () => binaryAssembleHangulCharacters('ㄱㄴ', 'ㅏ'),
-      Error,
+    expect(() => binaryAssembleHangulCharacters('ㄱㄴ', 'ㅏ')).toThrowError(
       'Invalid source character: ㄱㄴ. Source must be one character.'
     );
   });
 
   it('다음 문자가 한글 문자 한 글자가 아니라면 Invalid next character 에러를 발생시킨다.', () => {
-    assert.throws(
-      () => binaryAssembleHangulCharacters('ㄱ', 'a'),
-      Error,
+    expect(() => binaryAssembleHangulCharacters('ㄱ', 'a')).toThrowError(
       'Invalid next character: a. Next character must be one of the chosung, jungsung, or jongsung.'
     );
-    assert.throws(
-      () => binaryAssembleHangulCharacters('ㄱ', 'ㅡㅏ'),
-      Error,
+    expect(() => binaryAssembleHangulCharacters('ㄱ', 'ㅡㅏ')).toThrowError(
       'Invalid next character: ㅡㅏ. Next character must be one of the chosung, jungsung, or jongsung.'
     );
   });
@@ -164,10 +156,10 @@ describe('binaryAssembleHangul', () => {
 
   describe('assertHangul', () => {
     it('한글 문자열을 받으면 에러를 발생시키지 않는다.', () => {
-      expect(() => assertHangul('ㄱ')).not.toThrow();
-      expect(() => assertHangul('고양이')).not.toThrow();
-      expect(() => assertHangul('저는 고양이를 좋아합니다')).not.toThrow();
-      expect(() => assertHangul('저는 고양이를 좋아합니ㄷ')).not.toThrow();
+      expect(() => assertHangul('ㄱ')).not.toThrowError();
+      expect(() => assertHangul('고양이')).not.toThrowError();
+      expect(() => assertHangul('저는 고양이를 좋아합니다')).not.toThrowError();
+      expect(() => assertHangul('저는 고양이를 좋아합니ㄷ')).not.toThrowError();
     });
 
     it("한글 문자열이 아닌 값을 받으면 '___ is not a valid hangul string' 에러를 발생시킨다.", () => {

--- a/src/combineHangulCharacter.spec.ts
+++ b/src/combineHangulCharacter.spec.ts
@@ -14,19 +14,19 @@ describe('combineHangulCharacter', () => {
   });
 
   it('초성이 될 수 없는 문자가 초성으로 입력되면 에러를 반환한다. (ㅏ, ㅏ, ㄱ)', () => {
-    assert.throws(() => combineHangulCharacter('ㅏ', 'ㅏ', 'ㄱ'), Error, 'Invalid hangul Characters: ㅏ, ㅏ, ㄱ');
+    expect(() => combineHangulCharacter('ㅏ', 'ㅏ', 'ㄱ')).toThrowError('Invalid hangul Characters: ㅏ, ㅏ, ㄱ');
   });
 
   it('중성이 될 수 없는 문자가 중성으로 입력되면 에러를 반환한다. (ㄱ, ㄴ, ㅃ)', () => {
-    assert.throws(() => combineHangulCharacter('ㄱ', 'ㄴ', 'ㅃ'), Error, 'Invalid hangul Characters: ㄱ, ㄴ, ㅃ');
+    expect(() => combineHangulCharacter('ㄱ', 'ㄴ', 'ㅃ')).toThrowError('Invalid hangul Characters: ㄱ, ㄴ, ㅃ');
   });
 
   it('종성이 될 수 없는 문자가 종성으로 입력되면 에러를 반환한다. (ㄱ, ㅏ, ㅃ)', () => {
-    assert.throws(() => combineHangulCharacter('ㄱ', 'ㅏ', 'ㅃ'), Error, 'Invalid hangul Characters: ㄱ, ㅏ, ㅃ');
+    expect(() => combineHangulCharacter('ㄱ', 'ㅏ', 'ㅃ')).toThrowError('Invalid hangul Characters: ㄱ, ㅏ, ㅃ');
   });
 
   it('온전한 한글 문자가 하나라도 입력되면 에러를 반환한다. (가, ㅏ, ㄱ)', () => {
-    assert.throws(() => combineHangulCharacter('가', 'ㅏ', 'ㄱ'), Error, 'Invalid hangul Characters: 가, ㅏ, ㄱ');
+    expect(() => combineHangulCharacter('가', 'ㅏ', 'ㄱ')).toThrowError('Invalid hangul Characters: 가, ㅏ, ㄱ');
   });
 });
 


### PR DESCRIPTION
## Overview
[https://github.com/toss/es-hangul/pull/135](https://github.com/toss/es-hangul/pull/135)
에러를 테스트할때 `assert.throws`, `toThrowError` 대신 일관되게 `toThrowError` 메서드를 사용합니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
