### PR TITLE
chore: eslint + vscode extension setting for cspell

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,15 +66,6 @@ module.exports = {
         ],
       },
     ],
-    '@cspell/spellchecker': [
-      'error',
-      {
-        cspell: {
-          words: ['choseong', 'jungseong', 'jongseong'],
-          // eslint-disable-next-line @cspell/spellchecker
-          flagWords: ['chosung', 'jungsung', 'jongsung'],
-        },
-      },
-    ],
+    '@cspell/spellchecker': 'error',
   },
 };

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,3 @@
+{
+  "words": ["choseong", "jungseong", "jongseong"]
+}

--- a/cspell.json
+++ b/cspell.json
@@ -1,3 +1,16 @@
 {
-  "words": ["choseong", "jungseong", "jongseong"]
+  "words": [
+    "chosung",
+    "jungsung",
+    "jongsung",
+    "josa",
+    "batchim",
+    "acronymize",
+    "jaso",
+    "raon",
+    "hanguls",
+    "nextra",
+    "jamo",
+    "jamos"
+  ]
 }

--- a/src/amountToHangul.spec.ts
+++ b/src/amountToHangul.spec.ts
@@ -10,10 +10,10 @@ describe('amountToHangul', () => {
   });
 
   it('숫자로 된 금액이 80글자를 넘을 시 에러 발생', () => {
-    const longNumberString = '1'.repeat(81);    
+    const longNumberString = '1'.repeat(81);
     expect(() => amountToHangul(longNumberString)).toThrowError(`convert range exceeded : ${longNumberString}`);
-  })
-  
+  });
+
   it('숫자 외 문자를 무시하여 반환', () => {
     expect(amountToHangul('120,030원')).toEqual('일십이만삼십');
   });

--- a/src/amountToHangul.ts
+++ b/src/amountToHangul.ts
@@ -36,9 +36,9 @@ export function amountToHangul(amount: string | number) {
   const decimalPart = tempDecimalPart?.replace(/0+$/, '');
 
   const result = [];
-  let pronunDigits = true;
+  let pronounceDigits = true;
 
-  if(integerPart === '0' || (integerPart === '' && tempDecimalPart)) {
+  if (integerPart === '0' || (integerPart === '' && tempDecimalPart)) {
     result.push(HANGUL_NUMBERS_FOR_DECIMAL[0]);
   } else {
     for (let i = 0; i < integerPart.length - 1; i++) {
@@ -49,13 +49,13 @@ export function amountToHangul(amount: string | number) {
 
         if (hangulNumber) {
           result.push(hangulNumber);
-          pronunDigits = true;
+          pronounceDigits = true;
         }
       }
 
-      if (pronunDigits && digit % 4 === 0) {
+      if (pronounceDigits && digit % 4 === 0) {
         result.push(HANGUL_DIGITS[digit / 4]);
-        pronunDigits = false;
+        pronounceDigits = false;
       }
 
       if (integerPart[i] !== '0') {

--- a/src/combineHangulCharacter.ts
+++ b/src/combineHangulCharacter.ts
@@ -1,5 +1,5 @@
 import {
-  COMPLETE_HANGUL_START_CHARCODE,
+  COMPLETE_HANGUL_START_CHAR_CODE,
   DISASSEMBLED_VOWELS_BY_VOWEL,
   HANGUL_CHARACTERS_BY_FIRST_INDEX,
   HANGUL_CHARACTERS_BY_LAST_INDEX,
@@ -45,7 +45,7 @@ export function combineHangulCharacter(firstCharacter: string, middleCharacter: 
   const firstIndexOfTargetVowel = middleCharacterIndex * numOfLastCharacters;
 
   const unicode =
-    COMPLETE_HANGUL_START_CHARCODE + firstIndexOfTargetConsonant + firstIndexOfTargetVowel + lastCharacterIndex;
+    COMPLETE_HANGUL_START_CHAR_CODE + firstIndexOfTargetConsonant + firstIndexOfTargetVowel + lastCharacterIndex;
 
   return String.fromCharCode(unicode);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,17 +1,17 @@
-export const COMPLETE_HANGUL_START_CHARCODE = '가'.charCodeAt(0);
-export const COMPLETE_HANGUL_END_CHARCODE = '힣'.charCodeAt(0);
+export const COMPLETE_HANGUL_START_CHAR_CODE = '가'.charCodeAt(0);
+export const COMPLETE_HANGUL_END_CHAR_CODE = '힣'.charCodeAt(0);
 export const NUMBER_OF_JONGSUNG = 28;
 export const NUMBER_OF_JUNGSUNG = 21;
 
 const _JASO_HANGUL_NFD = [...'각힣'.normalize('NFD')].map(char => char.charCodeAt(0)); // NFC 에 정의되지 않은 문자는 포함하지 않음
 export const JASO_HANGUL_NFD = {
-  START_CHOSEONG: _JASO_HANGUL_NFD[0], // ㄱ
-  START_JUNGSEONG: _JASO_HANGUL_NFD[1], // ㅏ
-  START_JONGSEONG: _JASO_HANGUL_NFD[2], // ㄱ
-  END_CHOSEONG: _JASO_HANGUL_NFD[3], // ㅎ
-  END_JUNGSEONG: _JASO_HANGUL_NFD[4], // ㅣ
-  END_JONGSEONG: _JASO_HANGUL_NFD[5], // ㅎ
-}
+  START_CHOSUNG: _JASO_HANGUL_NFD[0], // ㄱ
+  START_JUNGSUNG: _JASO_HANGUL_NFD[1], // ㅏ
+  START_JONGSUNG: _JASO_HANGUL_NFD[2], // ㄱ
+  END_CHOSUNG: _JASO_HANGUL_NFD[3], // ㅎ
+  END_JUNGSUNG: _JASO_HANGUL_NFD[4], // ㅣ
+  END_JONGSUNG: _JASO_HANGUL_NFD[5], // ㅎ
+};
 
 /**
  * ㄱ -> 'ㄱ'

--- a/src/convertQwertyToHangulAlphabet.spec.ts
+++ b/src/convertQwertyToHangulAlphabet.spec.ts
@@ -23,6 +23,7 @@ describe('convertQwertyToHangulAlphabet', () => {
 
   it('영문 대문자는 쌍자/모음으로 바꾼다.', () => {
     expect(convertQwertyToHangulAlphabet('RㅏㄱEㅜrl')).toBe('ㄲㅏㄱㄸㅜㄱㅣ');
+    // eslint-disable-next-line @cspell/spellchecker
     expect(convertQwertyToHangulAlphabet('ㅇPdml')).toBe('ㅇㅖㅇㅡㅣ');
   });
 
@@ -34,11 +35,13 @@ describe('convertQwertyToHangulAlphabet', () => {
 describe('convertQwertyToHangul', () => {
   it('영어 알파벳을 한글로 합성한다.', () => {
     expect(convertQwertyToHangul('abc')).toBe('뮻');
+    // eslint-disable-next-line @cspell/spellchecker
     expect(convertQwertyToHangul('vmfhsxmdpsem')).toBe('프론트엔드');
   });
 
   it('쌍/자모음에 대응하지 않는 영어 알파벳을 한글로 합성한다.', () => {
     expect(convertQwertyToHangul('ABC')).toBe('뮻');
+    // eslint-disable-next-line @cspell/spellchecker
     expect(convertQwertyToHangul('VMFHSXM')).toBe('프론트');
   });
 
@@ -52,6 +55,7 @@ describe('convertQwertyToHangul', () => {
 
   it('영문 대문자는 쌍자/모음에 대응하며 한글로 합성한다.', () => {
     expect(convertQwertyToHangul('RㅏㄱEㅜrl')).toBe('깍뚜기');
+    // eslint-disable-next-line @cspell/spellchecker
     expect(convertQwertyToHangul('ㅇPdml')).toBe('예의');
   });
 

--- a/src/disassemble.ts
+++ b/src/disassemble.ts
@@ -41,5 +41,8 @@ export function disassembleHangulToGroups(str: string) {
 }
 
 export function disassembleHangul(str: string) {
-  return disassembleHangulToGroups(str).reduce((hanguls, disassembleds) => `${hanguls}${disassembleds.join('')}`, '');
+  return disassembleHangulToGroups(str).reduce(
+    (hanguls, disassembledHanguls) => `${hanguls}${disassembledHanguls.join('')}`,
+    ''
+  );
 }

--- a/src/disassembleCompleteHangulCharacter.ts
+++ b/src/disassembleCompleteHangulCharacter.ts
@@ -1,6 +1,6 @@
 import {
-  COMPLETE_HANGUL_END_CHARCODE,
-  COMPLETE_HANGUL_START_CHARCODE,
+  COMPLETE_HANGUL_END_CHAR_CODE,
+  COMPLETE_HANGUL_START_CHAR_CODE,
   HANGUL_CHARACTERS_BY_FIRST_INDEX,
   HANGUL_CHARACTERS_BY_LAST_INDEX,
   HANGUL_CHARACTERS_BY_MIDDLE_INDEX,
@@ -33,13 +33,13 @@ export function disassembleCompleteHangulCharacter(
 ): ReturnTypeDisassembleCompleteHangulCharacter | undefined {
   const charCode = letter.charCodeAt(0);
 
-  const isCompleteHangul = COMPLETE_HANGUL_START_CHARCODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHARCODE;
+  const isCompleteHangul = COMPLETE_HANGUL_START_CHAR_CODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHAR_CODE;
 
   if (!isCompleteHangul) {
     return undefined;
   }
 
-  const hangulCode = charCode - COMPLETE_HANGUL_START_CHARCODE;
+  const hangulCode = charCode - COMPLETE_HANGUL_START_CHAR_CODE;
 
   const lastIndex = hangulCode % NUMBER_OF_JONGSUNG;
   const middleIndex = ((hangulCode - lastIndex) / NUMBER_OF_JONGSUNG) % NUMBER_OF_JUNGSUNG;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import {
-  COMPLETE_HANGUL_START_CHARCODE,
-  COMPLETE_HANGUL_END_CHARCODE,
+  COMPLETE_HANGUL_START_CHAR_CODE,
+  COMPLETE_HANGUL_END_CHAR_CODE,
   HANGUL_CHARACTERS_BY_FIRST_INDEX,
   HANGUL_CHARACTERS_BY_LAST_INDEX,
   HANGUL_CHARACTERS_BY_MIDDLE_INDEX,
@@ -9,12 +9,12 @@ import {
 } from './constants';
 import { disassembleHangulToGroups } from './disassemble';
 
-const EXTRACT_CHOSEONG_REGEX = new RegExp(
-  `[^\\u${JASO_HANGUL_NFD.START_CHOSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_CHOSEONG.toString(16)}ㄱ-ㅎ\\s]+`,
+const EXTRACT_CHOSUNG_REGEX = new RegExp(
+  `[^\\u${JASO_HANGUL_NFD.START_CHOSUNG.toString(16)}-\\u${JASO_HANGUL_NFD.END_CHOSUNG.toString(16)}ㄱ-ㅎ\\s]+`,
   'ug'
 );
-const CHOOSE_NFD_CHOSEONG_REGEX = new RegExp(
-  `[\\u${JASO_HANGUL_NFD.START_CHOSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_CHOSEONG.toString(16)}]`,
+const CHOOSE_NFD_CHOSUNG_REGEX = new RegExp(
+  `[\\u${JASO_HANGUL_NFD.START_CHOSUNG.toString(16)}-\\u${JASO_HANGUL_NFD.END_CHOSUNG.toString(16)}]`,
   'g'
 );
 
@@ -39,13 +39,13 @@ export function hasBatchim(str: string) {
     return false;
   }
   const charCode = lastChar.charCodeAt(0);
-  const isCompleteHangul = COMPLETE_HANGUL_START_CHARCODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHARCODE;
+  const isCompleteHangul = COMPLETE_HANGUL_START_CHAR_CODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHAR_CODE;
 
   if (!isCompleteHangul) {
     return false;
   }
 
-  return (charCode - COMPLETE_HANGUL_START_CHARCODE) % NUMBER_OF_JONGSUNG > 0;
+  return (charCode - COMPLETE_HANGUL_START_CHAR_CODE) % NUMBER_OF_JONGSUNG > 0;
 }
 
 /**
@@ -70,13 +70,13 @@ export function hasSingleBatchim(str: string) {
     return false;
   }
   const charCode = lastChar.charCodeAt(0);
-  const isCompleteHangul = COMPLETE_HANGUL_START_CHARCODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHARCODE;
+  const isCompleteHangul = COMPLETE_HANGUL_START_CHAR_CODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHAR_CODE;
 
   if (!isCompleteHangul) {
     return false;
   }
 
-  const batchimCode = (charCode - COMPLETE_HANGUL_START_CHARCODE) % NUMBER_OF_JONGSUNG;
+  const batchimCode = (charCode - COMPLETE_HANGUL_START_CHAR_CODE) % NUMBER_OF_JONGSUNG;
   return HANGUL_CHARACTERS_BY_LAST_INDEX[batchimCode].length === 1;
 }
 
@@ -96,9 +96,10 @@ export function hasSingleBatchim(str: string) {
  * getChosung('띄어 쓰기') // 'ㄸㅇ ㅆㄱ'
  */
 export function getChosung(word: string) {
-  return word.normalize('NFD')
-    .replace(EXTRACT_CHOSEONG_REGEX, '') // NFD ㄱ-ㅎ, NFC ㄱ-ㅎ 외 문자 삭제
-    .replace(CHOOSE_NFD_CHOSEONG_REGEX, $0 => HANGUL_CHARACTERS_BY_FIRST_INDEX[$0.charCodeAt(0) - 0x1100]); // NFD to NFC
+  return word
+    .normalize('NFD')
+    .replace(EXTRACT_CHOSUNG_REGEX, '') // NFD ㄱ-ㅎ, NFC ㄱ-ㅎ 외 문자 삭제
+    .replace(CHOOSE_NFD_CHOSUNG_REGEX, $0 => HANGUL_CHARACTERS_BY_FIRST_INDEX[$0.charCodeAt(0) - 0x1100]); // NFD to NFC
 }
 
 /**


### PR DESCRIPTION
## Overview

기존 세팅은 vscode extension 을 쓰시는 분들에게는 여전히 오타로 표기되는 문제가 있습니다. 
eslint 설정과 vscode extension 모두 대응하기 위한 방법으로 cspell.json 을 추가합니다.

Before
<img width="1055" alt="image" src="https://github.com/toss/es-hangul/assets/57122180/22cbbe12-edce-44a1-bb69-7dad01053eae">

After
<img width="1020" alt="image" src="https://github.com/toss/es-hangul/assets/57122180/7222e493-f11a-45dd-a674-f189ac92f77f">


<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
