### PR TITLE
fix: vitest ESLint parsing error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
-  "include": ["src", ".eslintrc.js", "packlint.config.mjs"]
+  "include": ["src", ".eslintrc.js", "packlint.config.mjs", "vitest.config.mts"]
 }


### PR DESCRIPTION
## Overview

eslintrc의 parseOptions.project 값에 의해 vitest.config.mts 파일을 include 해야 합니다.

![image](https://github.com/toss/es-hangul/assets/55759551/916378fd-7dfd-4401-beb3-387a572d3822)


inlcude에 파일 경로를 추가할 시 tsconfig의 설정이 적용되어 다음과 같은 오류가 발생합니다.

![image](https://github.com/toss/es-hangul/assets/55759551/401c51d2-a166-4cf4-8f1c-393310632e6e)

tsconfig의 `resolveJsonModule` 옵션을 활성화하여 해결하였습니다.

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
