### PR TITLE
feat: 문자열 내부에 자음이나 모음이 문자로서 조합이 가능한지 검사하는 함수 `needAssemble`를 추가

### DIFF
--- a/docs/src/pages/docs/api/needAssemble.en.md
+++ b/docs/src/pages/docs/api/needAssemble.en.md
@@ -1,0 +1,22 @@
+---
+title: needAssemble
+---
+
+# needAssemble
+
+Find consonants and vowels within the string and check if they can be combined with complete Korean characters.
+
+For detailed examples, see below.
+
+```typescript
+function needAssemble(hangul: string): boolean;
+```
+
+## Examples
+
+```tsx
+needAssemble('아버지가 방에 들어갑니다'); // false
+needAssemble('아버지가 방ㅇㅔ 들어갑니다'); // true
+needAssemble('아버지가 방에 들어갑니다ㅇ'); // true
+needAssemble('아버지가 방에 들어갑닏ㅏ'); // true
+```

--- a/docs/src/pages/docs/api/needAssemble.ko.md
+++ b/docs/src/pages/docs/api/needAssemble.ko.md
@@ -1,0 +1,22 @@
+---
+title: needAssemble
+---
+
+# needAssemble
+
+문자열 안에서 자음과 모음을 찾고 완전한 한글 문자로 조합이 가능한지 검사합니다.
+
+자세한 예시는 아래 Example을 참고하세요.
+
+```typescript
+function needAssemble(hangul: string): boolean;
+```
+
+## Examples
+
+```tsx
+needAssemble('아버지가 방에 들어갑니다'); // false
+needAssemble('아버지가 방ㅇㅔ 들어갑니다'); // true
+needAssemble('아버지가 방에 들어갑니다ㅇ'); // true
+needAssemble('아버지가 방에 들어갑닏ㅏ'); // true
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export * from './removeLastHangulCharacter';
 export * from './utils';
 export * from './extractHangul';
 export * from './acronymizeHangul';
+export * from './needAssemble';

--- a/src/needAssemble.spec.ts
+++ b/src/needAssemble.spec.ts
@@ -1,0 +1,22 @@
+import { needAssemble } from "./needAssemble";
+
+describe('needAssemble', () => {
+  it('온전한 한글 문장', () => {
+    expect(needAssemble('아버지가 방에 들어갑니다')).toBe(false);
+  });
+  it('온전하지 않지만 합성 불가능한 한글 문장', () => {
+    expect(needAssemble('아버지가 방에 들어갑니다ㅏ')).toBe(false);
+    expect(needAssemble('ㄱ아버지가 방에 들어갑니다')).toBe(false);
+  });
+  it('모음과 자음이 나눠져있는 문장', () => {
+    expect(needAssemble('아버지가 방ㅇㅔ 들어갑니다')).toBe(true);
+  });
+  it('자음이 나누어져있는 문장', () => {
+    expect(needAssemble('아버지가 방에 들어갑니다ㅇ')).toBe(true);
+    expect(needAssemble('갑ㅅ을 치루다')).toBe(true);
+  });
+  it('모음이 나누어져있는 문장', () => {
+    expect(needAssemble('아버지가 방에 들어갑닏ㅏ')).toBe(true);
+    expect(needAssemble('아버지가 고ㅏ자를 드십니다')).toBe(true);
+  });
+});

--- a/src/needAssemble.spec.ts
+++ b/src/needAssemble.spec.ts
@@ -6,7 +6,8 @@ describe('needAssemble', () => {
   });
   it('온전하지 않지만 합성 불가능한 한글 문장', () => {
     expect(needAssemble('아버지가 방에 들어갑니다ㅏ')).toBe(false);
-    expect(needAssemble('ㄱ아버지가 방에 들어갑니다')).toBe(false);
+    expect(needAssemble('아버지가 방ㅇ에 들어갑니다')).toBe(false);
+    expect(needAssemble('아버지가 ㅇ에 들어갑니다')).toBe(false);
   });
   it('모음과 자음이 나눠져있는 문장', () => {
     expect(needAssemble('아버지가 방ㅇㅔ 들어갑니다')).toBe(true);

--- a/src/needAssemble.ts
+++ b/src/needAssemble.ts
@@ -1,0 +1,47 @@
+import { disassembleCompleteHangulCharacter } from "./disassembleCompleteHangulCharacter";
+import { canBeChosung, canBeJongsung, canBeJungsung, hasBatchim, hasSingleBatchim } from "./utils";
+
+/**
+ * 
+ * @name needAssemble
+ * @description
+ * 한글 문자열중 자음이나 모음이 있다면 완전한 문자로 조합 가능한지 검사합니다.
+ * @param hangul 변환하고자 하는 한글 문자열
+ * @returns 문자로 조합 가능한지 여부
+ */
+export function needAssemble(hangul: string): boolean {
+  for (const Jamo of hangul.matchAll(/[ㄱ-ㅎㅏ-ㅣ]/g)) {
+    const letter = Jamo[0];
+    const previous = Jamo.index - 1;
+
+    const previousCharacter = hangul.slice(previous, previous + 1);
+    if (canBeChosung(previousCharacter) && canBeJungsung(letter)) {
+      return true;
+    }
+    const isPreviousCompleteHangul = /[가-힣]/.test(previousCharacter);
+    if (isPreviousCompleteHangul) {
+      if (hasBatchim(previousCharacter) === false && canBeJongsung(letter)) {
+        return true;
+      }
+      if (hasSingleBatchim(previousCharacter)) {
+        const previousBatchim = disassembleCompleteHangulCharacter(previousCharacter)?.last;
+        if(canBeJongsung(previousBatchim + letter))
+        {
+          return true;
+        }
+      }
+      if (hasBatchim(previousCharacter)) {
+        return true;
+      }
+      if (hasBatchim(previousCharacter) === false)
+      {
+        const previousJungSung = disassembleCompleteHangulCharacter(previousCharacter)?.middle;
+        if (canBeJungsung(previousJungSung + letter))
+        {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}

--- a/src/needAssemble.ts
+++ b/src/needAssemble.ts
@@ -13,31 +13,32 @@ export function needAssemble(hangul: string): boolean {
   for (const Jamo of hangul.matchAll(/[ㄱ-ㅎㅏ-ㅣ]/g)) {
     const letter = Jamo[0];
     const previous = Jamo.index - 1;
-
     const previousCharacter = hangul.slice(previous, previous + 1);
+
     if (canBeChosung(previousCharacter) && canBeJungsung(letter)) {
       return true;
     }
+
     const isPreviousCompleteHangul = /[가-힣]/.test(previousCharacter);
     if (isPreviousCompleteHangul) {
       if (hasBatchim(previousCharacter) === false && canBeJongsung(letter)) {
         return true;
       }
+
       if (hasSingleBatchim(previousCharacter)) {
         const previousBatchim = disassembleCompleteHangulCharacter(previousCharacter)?.last;
-        if(canBeJongsung(previousBatchim + letter))
-        {
+        if(canBeJongsung(previousBatchim + letter)) {
           return true;
         }
       }
-      if (hasBatchim(previousCharacter)) {
+
+      if (hasBatchim(previousCharacter) && canBeJungsung(letter)){
         return true;
       }
-      if (hasBatchim(previousCharacter) === false)
-      {
+      
+      if (hasBatchim(previousCharacter) === false) {
         const previousJungSung = disassembleCompleteHangulCharacter(previousCharacter)?.middle;
-        if (canBeJungsung(previousJungSung + letter))
-        {
+        if (canBeJungsung(previousJungSung + letter)) {
           return true;
         }
       }

--- a/src/needAssemble.ts
+++ b/src/needAssemble.ts
@@ -2,12 +2,11 @@ import { disassembleCompleteHangulCharacter } from "./disassembleCompleteHangulC
 import { canBeChosung, canBeJongsung, canBeJungsung, hasBatchim, hasSingleBatchim } from "./utils";
 
 /**
- * 
  * @name needAssemble
  * @description
- * 한글 문자열중 자음이나 모음이 있다면 완전한 문자로 조합 가능한지 검사합니다.
- * @param hangul 변환하고자 하는 한글 문자열
- * @returns 문자로 조합 가능한지 여부
+ * 문자열 안에서 자음과 모음을 찾고 완전한 한글 문자로 조합이 가능한지 검사합니다.
+ * @param hangul 검사하고자 하는 한글 문자열
+ * @returns 조합가능한 문자가 하나라도 존재하는지 여부
  */
 export function needAssemble(hangul: string): boolean {
   for (const Jamo of hangul.matchAll(/[ㄱ-ㅎㅏ-ㅣ]/g)) {


### PR DESCRIPTION
## Overview

#129 에서 제안된 문자열 내부에 자음이나 모음이 문자로서 조합이 가능한지 검사하는 함수 `needAssemble`을 추가합니다.

```javascript
function needAssemble(hangul: string): boolean;

needAssemble('아버지가 방에 들어갑니다'); // false
needAssemble('아버지가 방ㅇㅔ 들어갑니다'); // true
needAssemble('아버지가 방에 들어갑니다ㅇ'); // true
needAssemble('아버지가 방에 들어갑닏ㅏ'); // true
```

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
