### PR TITLE
fix: useIsDarkMode의 초기값을 undefined로 설정

### DIFF
--- a/.changeset/six-clocks-matter.md
+++ b/.changeset/six-clocks-matter.md
@@ -1,5 +1,0 @@
----
-"docs": patch
----
-
-isDarkMode의 초기값을 undefined로 설정함.

--- a/.changeset/six-clocks-matter.md
+++ b/.changeset/six-clocks-matter.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+isDarkMode의 초기값을 undefined로 설정함.

--- a/docs/src/components/Sandpack/Sandpack.tsx
+++ b/docs/src/components/Sandpack/Sandpack.tsx
@@ -8,6 +8,10 @@ import { SandpackLogLevel } from '@codesandbox/sandpack-client';
 export function Sandpack({ files }: SandpackProps) {
   const isDarkMode = useIsDarkMode();
 
+  if (isDarkMode === undefined) {
+    return null;
+  }
+  
   return (
     <SandpackProvider
       template="vanilla-ts"

--- a/docs/src/components/Sandpack/Sandpack.tsx
+++ b/docs/src/components/Sandpack/Sandpack.tsx
@@ -2,37 +2,35 @@ import { SandpackProps, SandpackProvider } from '@codesandbox/sandpack-react';
 import { atomDark } from '@codesandbox/sandpack-themes';
 import { baseTemplate } from './baseTemplate';
 import { CustomPreset } from './CustomPreset';
-import { useIsDarkMode } from '@/hooks/use-is-dark-mode';
 import { SandpackLogLevel } from '@codesandbox/sandpack-client';
+import { ThemeMode } from '../theme-mode/ThemeMode';
 
 export function Sandpack({ files }: SandpackProps) {
-  const isDarkMode = useIsDarkMode();
-
-  if (isDarkMode === undefined) {
-    return null;
-  }
-  
   return (
-    <SandpackProvider
-      template="vanilla-ts"
-      theme={isDarkMode ? atomDark : undefined}
-      files={{
-        ...baseTemplate.files,
-        ...files,
-      }}
-      customSetup={{
-        dependencies: baseTemplate.dependencies,
-        devDependencies: baseTemplate.devDependencies,
-      }}
-      options={{
-        recompileDelay: 300,
-        initMode: 'user-visible',
-        initModeObserverOptions: { rootMargin: '1400px 0px' },
-        bundlerURL: 'https://sandpack-bundler.codesandbox.io/',
-        logLevel: SandpackLogLevel.None,
-      }}
-    >
-      <CustomPreset />
-    </SandpackProvider>
+    <ThemeMode>
+      {theme => (
+        <SandpackProvider
+          template="vanilla-ts"
+          theme={theme === 'dark' ? atomDark : undefined}
+          files={{
+            ...baseTemplate.files,
+            ...files,
+          }}
+          customSetup={{
+            dependencies: baseTemplate.dependencies,
+            devDependencies: baseTemplate.devDependencies,
+          }}
+          options={{
+            recompileDelay: 300,
+            initMode: 'user-visible',
+            initModeObserverOptions: { rootMargin: '1400px 0px' },
+            bundlerURL: 'https://sandpack-bundler.codesandbox.io/',
+            logLevel: SandpackLogLevel.None,
+          }}
+        >
+          <CustomPreset />
+        </SandpackProvider>
+      )}
+    </ThemeMode>
   );
 }

--- a/docs/src/components/introduction/Adopters.tsx
+++ b/docs/src/components/introduction/Adopters.tsx
@@ -1,6 +1,6 @@
-import { useIsDarkMode } from '@/hooks/use-is-dark-mode';
 import Image from 'next/image';
 import { ComponentProps } from 'react';
+import { ThemeMode } from '../theme-mode/ThemeMode';
 
 /**
  * 이 곳에 적용한 조직을 추가해주세요.
@@ -28,16 +28,18 @@ export const adopterLogoImagePropsList = [
 >;
 
 export const Adopters = () => {
-  const isDarkMode = useIsDarkMode();
-
-  if (isDarkMode === undefined) {
-    return null;
-  }
-
   return (
     <div className="flex flex-wrap gap-8 justify-center">
       {adopterLogoImagePropsList.map(({ darkSrc, src, alt, ...props }) => (
-        <Image key={src} src={isDarkMode ? darkSrc : src} alt={alt} {...props} />
+        <ThemeMode key={src}>
+          {(theme) => (
+            <Image
+              src={theme === 'dark' ? darkSrc : src}
+              alt={alt}
+              {...props}
+            />
+          )}
+        </ThemeMode>
       ))}
     </div>
   );

--- a/docs/src/components/introduction/Adopters.tsx
+++ b/docs/src/components/introduction/Adopters.tsx
@@ -30,6 +30,10 @@ export const adopterLogoImagePropsList = [
 export const Adopters = () => {
   const isDarkMode = useIsDarkMode();
 
+  if (isDarkMode === undefined) {
+    return null;
+  }
+
   return (
     <div className="flex flex-wrap gap-8 justify-center">
       {adopterLogoImagePropsList.map(({ darkSrc, src, alt, ...props }) => (

--- a/docs/src/components/theme-mode/ThemeMode.tsx
+++ b/docs/src/components/theme-mode/ThemeMode.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useIsDarkMode } from '@/hooks/use-is-dark-mode';
+
+interface ThemeModeProps {
+  children: (theme: 'dark' | 'light') => React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+export function ThemeMode({ children, fallback = null }: ThemeModeProps) {
+  const isDarkMode = useIsDarkMode();
+
+  if (isDarkMode == null) {
+    return fallback;
+  }
+
+  return children(isDarkMode ? 'dark' : 'light');
+}

--- a/docs/src/hooks/use-is-dark-mode.ts
+++ b/docs/src/hooks/use-is-dark-mode.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 export function useIsDarkMode() {
   const { resolvedTheme } = useTheme();
-  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState<boolean>();
 
   useEffect(() => {
     setIsDarkMode(resolvedTheme === 'dark');

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -20,6 +20,10 @@ const config: DocsThemeConfig = {
   logo: function useLogo() {
     const isDarkMode = useIsDarkMode();
 
+    if (isDarkMode === undefined) {
+      return null;
+    }
+
     return <Image src={isDarkMode ? '/logo-white.png' : '/logo.png'} alt="logo" width={120} height={48} priority />;
   },
   head: function useHead() {
@@ -99,6 +103,10 @@ const config: DocsThemeConfig = {
   footer: {
     text: function useText() {
       const isDarkMode = useIsDarkMode();
+
+      if (isDarkMode === undefined) {
+        return null;
+      }
 
       return (
         <div className="flex w-full flex-col items-center sm:items-start">

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -1,4 +1,4 @@
-import { useIsDarkMode } from '@/hooks/use-is-dark-mode';
+import { ThemeMode } from '@/components/theme-mode/ThemeMode';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import type { DocsThemeConfig } from 'nextra-theme-docs';
@@ -17,15 +17,13 @@ const config: DocsThemeConfig = {
       };
     }
   },
-  logo: function useLogo() {
-    const isDarkMode = useIsDarkMode();
-
-    if (isDarkMode === undefined) {
-      return null;
-    }
-
-    return <Image src={isDarkMode ? '/logo-white.png' : '/logo.png'} alt="logo" width={120} height={48} priority />;
-  },
+  logo: (
+    <ThemeMode>
+      {theme => (
+        <Image src={theme === 'dark' ? '/logo-white.png' : '/logo.png'} alt="logo" width="120" height="48" priority />
+      )}
+    </ThemeMode>
+  ),
   head: function useHead() {
     const { title } = useConfig();
 
@@ -101,36 +99,32 @@ const config: DocsThemeConfig = {
     toggleButton: true,
   },
   footer: {
-    text: function useText() {
-      const isDarkMode = useIsDarkMode();
-
-      if (isDarkMode === undefined) {
-        return null;
-      }
-
-      return (
-        <div className="flex w-full flex-col items-center sm:items-start">
-          <div>
-            <a
-              className="flex items-center gap-1 text-current"
-              target="_blank"
-              rel="noopener noreferrer"
-              title="toss homepage"
-              href="https://toss.im"
-            >
-              <span>Powered by</span>
-              <Image
-                src={isDarkMode ? '/toss-logo-white.png' : '/toss-logo-gray.png'}
-                alt="Toss"
-                width="64"
-                height="32"
-              />
-            </a>
-          </div>
-          <p className="mt-6 text-xs">© {new Date().getFullYear()} Viva Republica, Inc.</p>
+    text: (
+      <div className="flex w-full flex-col items-center sm:items-start">
+        <div>
+          <a
+            className="flex items-center gap-1 text-current"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="toss homepage"
+            href="https://toss.im"
+          >
+            <span>Powered by</span>
+            <ThemeMode>
+              {theme => (
+                <Image
+                  src={theme === 'dark' ? '/toss-logo-white.png' : '/toss-logo-gray.png'}
+                  alt="Toss"
+                  width="64"
+                  height="32"
+                />
+              )}
+            </ThemeMode>
+          </a>
         </div>
-      );
-    },
+        <p className="mt-6 text-xs">© {new Date().getFullYear()} Viva Republica, Inc.</p>
+      </div>
+    ),
   },
   toc: {
     backToTop: true,


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->
**useIsDarkMode의 초기값을 undefined로 설정**합니다. 

기존의 방식은 다크 모드를 인식하기 전에 초기값 false를 노출시켜 오해를 일으킬 수 있다고 보았습니다. 
따라서 undefined일 때는 null을 반환하는 방식으로 구현하여 모드가 제대로 인식되기 전에는 이미지가 노출되지 않도록 변경하였습니다.

예를 들어 화이트 모드일 경우, 
1)다크 이미지가 불필요함에도 이미지를 가져오고 있고 
2)이미지 변경이 일어나 깜박임 현상이 발생했습니다. 

따라서 초기값을 undefined로 설정하여 불필요한 이미지를 가져오는 것을 없애고 이미지 노출을 막아 깜박임 현상을 해결하였습니다.

**[변경 전]**
<img width="1680" alt="as-is" src="https://github.com/user-attachments/assets/7978c85a-c4b5-47ef-95ba-9f49169a7daa">

**[변경 후]**
<img width="1680" alt="to-be" src="https://github.com/user-attachments/assets/cea97f75-46f2-4ded-afef-39d9fc955e97">

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
