### PR TITLE
docs: API 메뉴트리에서 함수명이 카멜케이스로 나오도록합니다

### DIFF
--- a/docs/src/pages/docs/api/canBe.en.md
+++ b/docs/src/pages/docs/api/canBe.en.md
@@ -1,3 +1,7 @@
+---
+title: canBe
+---
+
 # canBeChoseong
 
 Check if a given character can be a choseong in Korean.

--- a/docs/src/pages/docs/api/canBe.ko.md
+++ b/docs/src/pages/docs/api/canBe.ko.md
@@ -1,3 +1,7 @@
+---
+title: canBe
+---
+
 # canBeChoseong
 
 인자로 받은 문자가 초성으로 위치할 수 있는 문자인지 검사합니다.

--- a/docs/src/pages/docs/api/getChoseong.en.mdx
+++ b/docs/src/pages/docs/api/getChoseong.en.mdx
@@ -1,5 +1,8 @@
-# getChoseong
+---
+title: getChoseong
+---
 
+# getChoseong
 
 Extracts the Choseong from a Korean word. (Example: 사과 -> 'ㅅㄱ')
 

--- a/docs/src/pages/docs/api/getChoseong.ko.mdx
+++ b/docs/src/pages/docs/api/getChoseong.ko.mdx
@@ -1,3 +1,7 @@
+---
+title: getChoseong
+---
+
 # getChoseong
 
 단어에서 초성을 추출합니다. (예: `사과` -> `'ㅅㄱ'`)

--- a/docs/src/pages/docs/api/hasBatchim.en.mdx
+++ b/docs/src/pages/docs/api/hasBatchim.en.mdx
@@ -1,3 +1,7 @@
+---
+title: hasBatchim
+---
+
 # hasBatchim
 Checks if the last character of a Korean string has a batchim (jongseong).
 

--- a/docs/src/pages/docs/api/hasBatchim.ko.mdx
+++ b/docs/src/pages/docs/api/hasBatchim.ko.mdx
@@ -1,5 +1,8 @@
-# hasBatchim
+---
+title: hasBatchim
+---
 
+# hasBatchim
 
 한글 문자열의 마지막 글자가 받침이 있는지 확인합니다.
 


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

기존에는 아래와 같이 파스칼 케이스로 나와있었는데 카멜케이스로 나오도록 수정합니다
- CanBe
- HasBatchim 
- getChoseong

<img width="293" alt="image" src="https://github.com/user-attachments/assets/43b4f262-1ea2-4cb1-b239-2a39a750654b">


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
