### PR TITLE
fix: 단독으로 존재하는 겹자음의 `romanize` 지원

### DIFF
--- a/src/romanize.spec.ts
+++ b/src/romanize.spec.ts
@@ -64,6 +64,7 @@ describe('romanize', () => {
     expect(romanize('가나다라ㅁㅂㅅㅇ')).toBe('ganadarambs');
     expect(romanize('ㅏ')).toBe('a');
     expect(romanize('ㅘ')).toBe('wa');
+    expect(romanize('ㄳ')).toBe('gs');
   });
 
   it('특수문자는 로마자 표기로 변경하지 않는다', () => {

--- a/src/romanize.ts
+++ b/src/romanize.ts
@@ -43,12 +43,12 @@ const romanizeSyllableHangul = (arrayHangul: string[], index: number): string =>
     return choseong + jungseong + jongseong;
   }
 
-  if (syllable in 중성_알파벳_발음) {
-    return 중성_알파벳_발음[syllable as keyof typeof 중성_알파벳_발음];
+  if (hasProperty(중성_알파벳_발음, syllable)) {
+    return 중성_알파벳_발음[syllable];
   }
 
-  if (canBeChoseong(syllable)) {
-    return 초성_알파벳_발음[syllable as keyof typeof 초성_알파벳_발음];
+  if (hasProperty(초성_알파벳_발음, syllable)) {
+    return 초성_알파벳_발음[syllable];
   }
 
   return syllable;

--- a/src/romanize.ts
+++ b/src/romanize.ts
@@ -54,11 +54,14 @@ const romanizeSyllableHangul = (arrayHangul: string[], index: number): string =>
   }
 
   if (hasProperty(DISASSEMBLED_CONSONANTS_BY_CONSONANT, syllable)) {
-    return DISASSEMBLED_CONSONANTS_BY_CONSONANT[syllable].split('').reduce((acc, consonant) => {
-      assert(hasProperty(초성_알파벳_발음, consonant), `${consonant}에 해당하는 알파벳 발음이 존재하지 않습니다.`);
+    return DISASSEMBLED_CONSONANTS_BY_CONSONANT[syllable]
+      .split('')
+      .map(consonant => {
+        assert(hasProperty(초성_알파벳_발음, consonant), `${consonant}에 해당하는 알파벳 발음이 존재하지 않습니다.`);
 
-      return acc + 초성_알파벳_발음[consonant];
-    }, '');
+        return 초성_알파벳_발음[consonant];
+      })
+      .join('');
   }
 
   return syllable;

--- a/src/romanize.ts
+++ b/src/romanize.ts
@@ -1,9 +1,15 @@
+import assert from './_internal';
 import { isHangulCharacter } from './_internal/hangul';
 import { assembleHangul } from './assemble';
-import { 종성_알파벳_발음, 중성_알파벳_발음, 초성_알파벳_발음 } from './constants';
+import {
+  DISASSEMBLED_CONSONANTS_BY_CONSONANT,
+  종성_알파벳_발음,
+  중성_알파벳_발음,
+  초성_알파벳_발음,
+} from './constants';
 import { disassembleCompleteHangulCharacter } from './disassembleCompleteHangulCharacter';
 import { standardizePronunciation } from './standardizePronunciation';
-import { canBeChoseong } from './utils';
+import { hasProperty } from './utils';
 
 /**
  * 주어진 한글 문자열을 로마자로 변환합니다.
@@ -47,8 +53,12 @@ const romanizeSyllableHangul = (arrayHangul: string[], index: number): string =>
     return 중성_알파벳_발음[syllable];
   }
 
-  if (hasProperty(초성_알파벳_발음, syllable)) {
-    return 초성_알파벳_발음[syllable];
+  if (hasProperty(DISASSEMBLED_CONSONANTS_BY_CONSONANT, syllable)) {
+    return DISASSEMBLED_CONSONANTS_BY_CONSONANT[syllable].split('').reduce((acc, consonant) => {
+      assert(hasProperty(초성_알파벳_발음, consonant), `${consonant}에 해당하는 알파벳 발음이 존재하지 않습니다.`);
+
+      return acc + 초성_알파벳_발음[consonant];
+    }, '');
   }
 
   return syllable;


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

`romanize` 함수가 단독으로 존재하는 자음을 처리하는 로직을 개선합니다.

이제 단독으로 존재하는 겹자음의 경우도 처리가 가능합니다.

기존: `ㄳ` => `ㄳ`
변경: `ㄳ` => `gs`

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
