### PR TITLE
docs: 영문과 한글이 일치하지 않는 문제 수정

### DIFF
--- a/README-en_us.md
+++ b/README-en_us.md
@@ -18,8 +18,9 @@ const userInput = 'ㄹㅁ';
 
 const result = getChoseong(searchWord); // ㄹㅁ
 
+// Check if the 'choseong' of the search word match the user input
 if (result === userInput) {
-  // do something
+  something()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ const userInput = 'ㄹㅁ';
 
 const result = getChoseong(searchWord); // ㄹㅁ
 
+// 검색어의 초성과 사용자 입력 초성이 일치하는지 확인
 if (result === userInput) {
-  // 일치한다면 if문이 실행
+  something()
 }
 ```
 

--- a/docs/src/pages/docs/introduction.en.mdx
+++ b/docs/src/pages/docs/introduction.en.mdx
@@ -46,8 +46,9 @@ const userInput = 'ㄹㅁ';
 
 const result = getChoseong(searchWord); // ㄹㅁ
 
+// Check if the 'choseong' of the search word match the user input
 if (result === userInput) {
-  // do something
+  something()
 }
 ```
 

--- a/docs/src/pages/docs/introduction.ko.mdx
+++ b/docs/src/pages/docs/introduction.ko.mdx
@@ -46,8 +46,9 @@ const userInput = 'ㄹㅁ';
 
 const result = getChoseong(searchWord); // ㄹㅁ
 
+// 검색어의 초성과 사용자 입력 초성이 일치하는지 확인
 if (result === userInput) {
-  // 일치한다면 if문이 실행
+  something()
 }
 ```
 

--- a/docs/src/pages/index.en.mdx
+++ b/docs/src/pages/index.en.mdx
@@ -40,8 +40,9 @@ const userInput = 'ㄹㅁ';
 
 const result = getChoseong(searchWord); // ㄹㅁ
 
+// Check if the 'choseong' of the search word match the user input
 if(result === userInput){
-  // do something 
+  something()
 }
 ```
 

--- a/docs/src/pages/index.ko.mdx
+++ b/docs/src/pages/index.ko.mdx
@@ -40,8 +40,9 @@ const userInput = 'ㄹㅁ';
 
 const result = getChoseong(searchWord); // ㄹㅁ
 
+// 검색어의 초성과 사용자 입력 초성이 일치하는지 확인
 if(result === userInput){
-  // 일치한다면 if문이 실행 
+  something()
 }
 ```
 


### PR DESCRIPTION
## Overview

영문서와 한글 문서의 주석을 일치 시키고자 합니다.

### AS-IS
기존 문서는 다음과 같습니다. 

``` ts
// en 
if (result === userInput) {
  // do something
}
```

``` ts
// ko
if (result === userInput) {
  // 일치한다면 if문이 실행
}
```

### TO-BE
ko 문서의 주석은 es-hangul과는 관련없는 js 언어에 대한 설명이란 생각이 듭니다. 

다음과 같이 수정하였습니다.
- if 문의 조건에 대한 설명 추가
- if 문 내부에 주석 대신 something()으로 변경

``` ts
// en
// Check if the 'choseong' of the search word match the user input
if (result === userInput) {
  something()
}
```

``` ts 
// ko
// 검색어의 초성과 사용자 입력 초성이 일치하는지 확인
if (result === userInput) {
  something()
}
```

만약 if 문의 조건에 대한 설명이 필요 없다고 생각되신다면, 다음과 같이 `something()`으로 통일하는것은 어떨까요? 
> en의 `// do something`으로 통일하는것은 한글 문서에서는 적절하지 않은 생각이 들었습니다.

``` ts 
if (result === userInput) {
  something()
}
```

혹은 더 좋은 의견 있으시다면, 말씀 해주시면 반영하겠습니다. 감사합니다. :)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
