### PR TITLE
Update broken-link-checker.yml to avoid code injection vulnerability

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 5 * * 1-5'
   workflow_dispatch:
-    inputs: { url: { description: 'URL to check', required: false, default: 'https://es-toolkit.slash.page' } }
+    inputs: { url: { description: 'URL to check', required: false, default: 'https://es-hangul.slash.page' } }
 
 jobs:
   broken-link-checker:
@@ -20,5 +20,5 @@ jobs:
       - run: yarn install
       - name: Check broken link
         env:
-          url: ${{ github.event.inputs.url || 'https://es-toolkit.slash.page' }}
+          url: ${{ github.event.inputs.url || 'https://es-hangul.slash.page' }}
         run: yarn blc $url --ro

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 5 * * 1-5'
   workflow_dispatch:
-    inputs: { url: { description: 'URL to check', required: false, default: 'https://es-hangul.slash.page' } }
+    inputs: { url: { description: 'URL to check', required: false, default: 'https://es-toolkit.slash.page' } }
 
 jobs:
   broken-link-checker:
@@ -18,4 +18,7 @@ jobs:
           cache-dependency-path: 'yarn.lock'
           node-version-file: '.nvmrc'
       - run: yarn install
-      - run: yarn blc ${{ github.event.inputs.url }} --ro
+      - name: Check broken link
+        env:
+          url: ${{ github.event.inputs.url || 'https://es-toolkit.slash.page' }}
+        run: yarn blc $url --ro


### PR DESCRIPTION
I have updated the workflow to use environment variables to avoid code injection vulnerability. Please set up the environment variable accordingly.

## Overview

I found a code injection vulnerability in the es-hangul GitHub workflow process, which allows users to inject arbitrary OS commands during the workflow process.
The broken-link-checker.yml file uses variable interpolation in the run step with a user-controlled variable (github.event.inputs.url), which inputs user-data (untrusted) directly in a shell command. If an attacker can control or manipulate the github.event.inputs.url value (e.g., by submitting a malicious pull request or triggering an event with crafted input), they could inject shell commands.

**Proof of Concept (PoC):**

For ease of testing, I created a new event file which calls the broken-link-checker action and injects code after the original function.

vulntest.event:
``` 
{
  "action": "broken-link-checker",
  "inputs": {
      "url": "https://example.com; ls; whoami; echo 'Command Injection Successful'"
  }
}
```

I ran this in a GitHub codespace using the following command: (Note: The act package might need to be installed, which can be done following the steps here (https://www.freecodecamp.org/news/how-to-run-github-actions-locally/)

`act --job broken-link-checker --eventpath .github/workflows/vulntest.event`

The following screenshot shows the Github action running and the injected commands successfully being executed.

![image](https://github.com/user-attachments/assets/3ea52576-9d78-4591-96ad-031d9d953fba)


**References:**

GitHub Actions - Security For GitHub Actions
•	https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks
•	https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions


## PR Checklist

- [ x ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
