### PR TITLE
test: Fix missing parentheses in function call

### DIFF
--- a/src/disassembleCompleteCharacter/disassembleCompleteCharacter.spec.ts
+++ b/src/disassembleCompleteCharacter/disassembleCompleteCharacter.spec.ts
@@ -34,7 +34,7 @@ describe('disassembleCompleteCharacter', () => {
   });
 
   it('완전한 한글 문자열이 아니면 undefined를 반환해야 합니다.', () => {
-    expect(disassembleCompleteCharacter('ㄱ')).toBeUndefined;
-    expect(disassembleCompleteCharacter('ㅏ')).toBeUndefined;
+    expect(disassembleCompleteCharacter('ㄱ')).toBeUndefined();
+    expect(disassembleCompleteCharacter('ㅏ')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Overview
Fixed the issue where parentheses were missing in the function calls of 'disassembleCompleteCharacter' in the test code.



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
