### PR TITLE
fix: add return types to functions

### DIFF
--- a/src/assemble/assemble.ts
+++ b/src/assemble/assemble.ts
@@ -16,7 +16,7 @@ import { binaryAssemble } from '../_internal/hangul';
  * assemble(['아버지가', ' ', '방에 ', '들어갑니다']) // 아버지가 방에 들어갑니다
  * assemble(['ㅇ', 'ㅏ', 'ㅂ', 'ㅓ', 'ㅈ', 'ㅣ']) // 아버지
  */
-export function assemble(words: string[]) {
+export function assemble(words: string[]): string {
   const disassembled = disassemble(words.join('')).split('');
   return disassembled.reduce(binaryAssemble);
 }

--- a/src/combineCharacter/combineCharacter.ts
+++ b/src/combineCharacter/combineCharacter.ts
@@ -25,7 +25,7 @@ import { canBeChoseong, canBeJongseong, canBeJungseong } from '../canBe';
  * combineCharacter('ㄱ', 'ㅏ', 'ㅂㅅ') // '값'
  * combineCharacter('ㅌ', 'ㅗ') // '토'
  */
-export function combineCharacter(choseong: string, jungseong: string, jongseong = '') {
+export function combineCharacter(choseong: string, jungseong: string, jongseong = ''): string {
   if (canBeChoseong(choseong) === false || canBeJungseong(jungseong) === false || canBeJongseong(jongseong) === false) {
     throw new Error(`Invalid hangul Characters: ${choseong}, ${jungseong}, ${jongseong}`);
   }

--- a/src/disassemble/disassemble.ts
+++ b/src/disassemble/disassemble.ts
@@ -2,7 +2,7 @@ import { DISASSEMBLED_CONSONANTS_BY_CONSONANT, DISASSEMBLED_VOWELS_BY_VOWEL } fr
 import { hasProperty } from '../_internal';
 import { disassembleCompleteCharacter } from '../disassembleCompleteCharacter';
 
-export function disassembleToGroups(str: string) {
+export function disassembleToGroups(str: string): string[][] {
   /*
    * FIXME(@raon0211):
    * Array#map을 사용하는 경우 Safari에서 'Array size is not a small enough positive integer' 오류가 발생함.
@@ -44,6 +44,6 @@ export function disassembleToGroups(str: string) {
   return result;
 }
 
-export function disassemble(str: string) {
+export function disassemble(str: string): string {
   return disassembleToGroups(str).reduce((hanguls, disassembleds) => `${hanguls}${disassembleds.join('')}`, '');
 }

--- a/src/getChoseong/getChoseong.ts
+++ b/src/getChoseong/getChoseong.ts
@@ -15,7 +15,7 @@ import { JASO_HANGUL_NFD } from './constants';
  * getChoseong('사과') // 'ㅅㄱ'
  * getChoseong('띄어 쓰기') // 'ㄸㅇ ㅆㄱ'
  */
-export function getChoseong(word: string) {
+export function getChoseong(word: string): string {
   return word
     .normalize('NFD')
     .replace(EXTRACT_CHOSEONG_REGEX, '') // NFD ㄱ-ㅎ, NFC ㄱ-ㅎ 외 문자 삭제


### PR DESCRIPTION
## Overview

Added return types to the 'assemble', 'combineCharacter', 'disassembleToGroups', 'getChoseong' functions to match the documentation and improve type safety

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
