### PR TITLE
fix: remove duplicate code and improve function structure

### DIFF
--- a/src/susa/susa.ts
+++ b/src/susa/susa.ts
@@ -11,35 +11,7 @@ function getClassifierWord(num: number): string {
     return SUSA_CLASSIFIER_MAP[num];
   }
 
-  const tens = Math.floor(num / 10) * 10;
-  const ones = num % 10;
-
-  const tensWord = hasProperty(SUSA_MAP, tens) ? SUSA_MAP[tens] : '';
-
-  if (ones === 0) {
-    return tensWord;
-  }
-
-  if (hasProperty(SUSA_CLASSIFIER_MAP, ones)) {
-    const onesWord = SUSA_CLASSIFIER_MAP[ones];
-
-    return `${tensWord}${onesWord}`;
-  }
-
-  if (hasProperty(SUSA_MAP, ones)) {
-    const onesWord = SUSA_MAP[ones];
-
-    return `${tensWord}${onesWord}`;
-  }
-
-  // `susa`에서` `validateNumber` 하기 때문에 도달할 수 없는 분기입니다. 타입 추론을 위해 에러를 던져줍니다.
-  throw new Error('지원하지 않는 숫자입니다.');
-}
-
-function validateNumber(num: number): void {
-  if (Number.isNaN(num) || num <= 0 || num > 100 || !Number.isInteger(num) || !Number.isFinite(num)) {
-    throw new Error('지원하지 않는 숫자입니다.');
-  }
+  return getWord(num, SUSA_CLASSIFIER_MAP);
 }
 
 function getNumberWord(num: number): string {
@@ -47,11 +19,36 @@ function getNumberWord(num: number): string {
     return SUSA_MAP[100];
   }
 
+  return getWord(num, SUSA_MAP);
+}
+
+function getWord(num: number, map:Record<number,string> ): string {
   const tens = Math.floor(num / 10) * 10;
   const ones = num % 10;
-
   const tensWord = hasProperty(SUSA_MAP, tens) ? SUSA_MAP[tens] : '';
-  const onesWord = hasProperty(SUSA_MAP, ones) ? SUSA_MAP[ones] : '';
 
-  return `${tensWord}${onesWord}`;
+  if (ones === 0) {
+    return tensWord;
+  }
+
+  if(hasProperty(map, ones)){
+    const onesWord = map[ones];
+    return `${tensWord}${onesWord}`;
+  }
+
+  if (hasProperty(SUSA_MAP, ones)) {
+    const onesWord = SUSA_MAP[ones];
+    return `${tensWord}${onesWord}`;
+  }
+
+  // `susa`에서` `validateNumber` 하기 때문에 도달할 수 없는 분기입니다. 타입 추론을 위해 에러를 던져줍니다.
+  throw new Error('지원하지 않는 숫자입니다.');
 }
+
+
+function validateNumber(num: number): void {
+  if (Number.isNaN(num) || num <= 0 || num > 100 || !Number.isInteger(num) || !Number.isFinite(num)) {
+    throw new Error('지원하지 않는 숫자입니다.');
+  }
+}
+


### PR DESCRIPTION
## Overview
### Changes Made
- Removed duplicate code from the `getClassifierWord` and `getNumberWord` functions by extracting common logic into a new `getWord` function.
- Simplified the `getClassifierWord` and `getNumberWord` functions by passing `SUSA_MAP` and `SUSA_CLASSIFIER_MAP` as parameters to the `getWord` function.



## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
