### PR TITLE
fix: CSS 파일에서 공백이 있는 폰트 이름에 따옴표 추가 및 불필요한 * 제거

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -2,24 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
-* body {
+body {
   font-family:
-    Toss Product Sans,
+    'Toss Product Sans',
     Tossface,
     -apple-system,
     BlinkMacSystemFont,
-    Bazier Square,
-    Noto Sans KR,
-    Segoe UI,
-    Apple SD Gothic Neo,
+    'Bazier Square',
+    'Noto Sans KR',
+    'Segoe UI',
+    'Apple SD Gothic Neo',
     Roboto,
-    Helvetica Neue,
+    'Helvetica Neue',
     Arial,
     sans-serif,
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol,
-    Noto Color Emoji;
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    'Noto Color Emoji';
 }
 
 @layer utilities {


### PR DESCRIPTION
## Overview
- 공백이 포함된 폰트 이름(Toss Product Sans, Bazier Square 등)에 따옴표를 추가하여 CSS의 표준에 맞게 수정하였습니다.
- *body로 잘못 지정되어 있다고 생각하여 CSS 선택자를 body로 수정하여 불필요한 *를 제거하였습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
