### PR TITLE
fix:  convertQwertyToAlphabet 오타 수정

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - [#209](https://github.com/toss/es-hangul/pull/209) [`c15a9d1`](https://github.com/toss/es-hangul/commit/c15a9d18cff0bc36f7672f3d6ab38e422a625d34) Thanks [@kangju2000](https://github.com/kangju2000)! - docs: josa, josa.pick 문서에 demo를 추가합니다.
 
-- [#205](https://github.com/toss/es-hangul/pull/205) [`75ef7df`](https://github.com/toss/es-hangul/commit/75ef7dfb1e1e27f33cb3fb2e4ab3184b6d0901c6) Thanks [@anonymousRecords](https://github.com/anonymousRecords)! - fix: 문서 상단의 깃허브 아이콘이 제대로 보이지 않는 문제를 수정합니다
+- [#205](https://github.com/toss/es-hangul/pull/205) [`75ef7df`](https://github.com/toss/es-hangul/commit/75ef7dfb1e1e27f33cb3fb2e4ab3184b6d0901c6) Thanks [@anonymousRecords](https://github.com/anonymousRecords)! - fix : 문서 상단의 깃허브 아이콘이 제대로 보이지 않는 문제를 수정합니다
 
 ## 0.1.14
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 - [#209](https://github.com/toss/es-hangul/pull/209) [`c15a9d1`](https://github.com/toss/es-hangul/commit/c15a9d18cff0bc36f7672f3d6ab38e422a625d34) Thanks [@kangju2000](https://github.com/kangju2000)! - docs: josa, josa.pick 문서에 demo를 추가합니다.
 
-- [#205](https://github.com/toss/es-hangul/pull/205) [`75ef7df`](https://github.com/toss/es-hangul/commit/75ef7dfb1e1e27f33cb3fb2e4ab3184b6d0901c6) Thanks [@anonymousRecords](https://github.com/anonymousRecords)! - fix : 문서 상단의 깃허브 아이콘이 제대로 보이지 않는 문제를 수정합니다
+- [#205](https://github.com/toss/es-hangul/pull/205) [`75ef7df`](https://github.com/toss/es-hangul/commit/75ef7dfb1e1e27f33cb3fb2e4ab3184b6d0901c6) Thanks [@anonymousRecords](https://github.com/anonymousRecords)! - fix: 문서 상단의 깃허브 아이콘이 제대로 보이지 않는 문제를 수정합니다
 
 ## 0.1.14
 

--- a/src/convertQwertyToAlphabet/convertQwertyToAlphabet.ts
+++ b/src/convertQwertyToAlphabet/convertQwertyToAlphabet.ts
@@ -19,7 +19,7 @@ export function convertQwertyToAlphabet(word: string): string {
 /**
  * @name convertQwertyToHangul
  * @description
- * 영어 알파벳을 qwerty 자판과 매칭되는 한글 문자와 문장으로 변환합니다.
+ * 영어 알파벳을 qwerty 자판과 매칭과는 한글 문자와 문장으로 변환합니다.
  * @param word 한글 문장으로 변환하고자 하는 영문
  * @returns qwerty 영어 알파벳을 변환하여 한글 규칙에 맞게 합성한 문자열
  */

--- a/src/convertQwertyToAlphabet/convertQwertyToAlphabet.ts
+++ b/src/convertQwertyToAlphabet/convertQwertyToAlphabet.ts
@@ -19,7 +19,7 @@ export function convertQwertyToAlphabet(word: string): string {
 /**
  * @name convertQwertyToHangul
  * @description
- * 영어 알파벳을 qwerty 자판과 매칭과는 한글 문자와 문장으로 변환합니다.
+ * 영어 알파벳을 qwerty 자판과 매칭되는 한글 문자와 문장으로 변환합니다.
  * @param word 한글 문장으로 변환하고자 하는 영문
  * @returns qwerty 영어 알파벳을 변환하여 한글 규칙에 맞게 합성한 문자열
  */


### PR DESCRIPTION
## Overview
- CHANGELOG.md 파일의 불필요한 공백을 제거 및 convertQwertyToAlphabet.ts 파일의 오타를 수정했습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
