### PR TITLE
fix: josa 리턴 타입 보강

### DIFF
--- a/.changeset/gorgeous-shoes-check.md
+++ b/.changeset/gorgeous-shoes-check.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+fix: josa 리턴 타입 보강

--- a/src/josa/josa.ts
+++ b/src/josa/josa.ts
@@ -19,19 +19,21 @@ type JosaOption =
 
 const 로_조사: JosaOption[] = ['으로/로', '으로서/로서', '으로써/로써', '으로부터/로부터'];
 
-export function josa(word: string, josa: JosaOption): string {
+type ExtractJosaOption<T> = T extends `${infer A}/${infer B}` ? A | B : never;
+
+export function josa<T extends string, U extends JosaOption>(word: T, josa: U): `${T}${ExtractJosaOption<U>}` {
   if (word.length === 0) {
-    return word;
+    return word as `${T}${ExtractJosaOption<U>}`;
   }
 
-  return word + josaPicker(word, josa);
+  return (word + josaPicker(word, josa)) as `${T}${ExtractJosaOption<U>}`;
 }
 
 josa.pick = josaPicker;
 
-function josaPicker(word: string, josa: JosaOption): string {
+function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOption<T> {
   if (word.length === 0) {
-    return josa.split('/')[0];
+    return josa.split('/')[0] as ExtractJosaOption<T>;
   }
 
   const has받침 = hasBatchim(word);
@@ -51,5 +53,5 @@ function josaPicker(word: string, josa: JosaOption): string {
     index = 1;
   }
 
-  return josa.split('/')[index];
+  return josa.split('/')[index] as ExtractJosaOption<T>;
 }


### PR DESCRIPTION
## Overview

`josa`, `josa.picker` 의 리턴타입을 제네릭을 통해 개선하여 type-narrowing을 합니다.
![image](https://github.com/user-attachments/assets/e5d667e3-3449-4cf9-9215-4b826c55c066)


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
