### PR TITLE
docs: fix a typo in `standardizePronunciation.ko.mdx`

### DIFF
--- a/docs/src/pages/docs/api/standardizePronunciation.ko.mdx
+++ b/docs/src/pages/docs/api/standardizePronunciation.ko.mdx
@@ -26,7 +26,7 @@ function standardizePronunciation(
 ```tsx
 standardizePronunciation('디귿이'); // '디그시'
 standardizePronunciation('굳이'); // '구지'
-standardizePronunciation('담요'); // '딤뇨'
+standardizePronunciation('담요'); // '담뇨'
 standardizePronunciation('침략'); // '침냑'
 standardizePronunciation('먹는'); // '멍는'
 standardizePronunciation('신라'); // '실라'


### PR DESCRIPTION
## Overview

안녕하세요, `standardizePronunciation.ko.mdx` 문서를 읽다 오타를 발견하여 수정하였습니다.

`담뇨`가 올바른 표현으로 판단됩니다.

![image](https://github.com/user-attachments/assets/d8c3026c-a384-41d0-b016-6a674531c089)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
