### PR TITLE
chore: hasbatchim 함수의 조건문 검사 로직을 개선합니다.

### DIFF
--- a/.changeset/few-lies-give.md
+++ b/.changeset/few-lies-give.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+chore: hasbatchim 함수의 조건문 검사 로직을 개선합니다.

--- a/src/hasBatchim/hasBatchim.ts
+++ b/src/hasBatchim/hasBatchim.ts
@@ -35,7 +35,7 @@ export function hasBatchim(
     only?: 'single' | 'double';
   }
 ) {
-  const lastChar = str[str.length - 1];
+  const lastChar = str.charAt(str.length - 1);
 
   if (lastChar == null) {
     return false;

--- a/src/hasBatchim/hasBatchim.ts
+++ b/src/hasBatchim/hasBatchim.ts
@@ -41,9 +41,9 @@ export function hasBatchim(
     return false;
   }
   const charCode = lastChar.charCodeAt(0);
-  const isCompleteHangul = COMPLETE_HANGUL_START_CHARCODE <= charCode && charCode <= COMPLETE_HANGUL_END_CHARCODE;
+  const isNotCompleteHangul = charCode < COMPLETE_HANGUL_START_CHARCODE || charCode > COMPLETE_HANGUL_END_CHARCODE;
 
-  if (!isCompleteHangul) {
+  if (isNotCompleteHangul) {
     return false;
   }
 

--- a/src/hasBatchim/hasBatchim.ts
+++ b/src/hasBatchim/hasBatchim.ts
@@ -48,14 +48,17 @@ export function hasBatchim(
   }
 
   const batchimCode = (charCode - COMPLETE_HANGUL_START_CHARCODE) % NUMBER_OF_JONGSEONG;
+  const batchimLength = JONGSEONGS[batchimCode].length;
 
-  if (options?.only === 'single') {
-    return JONGSEONGS[batchimCode].length === 1;
+  switch (options?.only) {
+    case 'single': {
+      return batchimLength === 1;
+    }
+    case 'double': {
+      return batchimLength === 2;
+    }
+    default: {
+      return batchimCode > 0;
+    }
   }
-
-  if (options?.only === 'double') {
-    return JONGSEONGS[batchimCode].length === 2;
-  }
-
-  return batchimCode > 0;
 }

--- a/src/hasBatchim/hasBatchim.ts
+++ b/src/hasBatchim/hasBatchim.ts
@@ -35,7 +35,7 @@ export function hasBatchim(
     only?: 'single' | 'double';
   }
 ) {
-  const lastChar = str.charAt(str.length - 1);
+  const lastChar = str[str.length - 1];
 
   if (lastChar == null) {
     return false;


### PR DESCRIPTION
## Overview
다음과 같은 개선을 하였습니다.

- charCode가 한글인지를 AND로 개선하던 로직을 OR로 개선하여, 앞의 조건이 true 일 경우 뒤의 조건을 검사하지 않도록 하였습니다.
- options.only로 분기하던 if문을 switch case문으로 수정하여, options.only를 한 번의 분기만 하도록 수정하였습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
