### PR TITLE
chore: josa 함수의 계산과 분기를 최적화하였습니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,18 +44,18 @@
   ],
   "scripts": {
     "attw": "attw --pack",
+    "bench": "vitest bench",
     "build": "tsup",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version",
+    "docs:build": "yarn workspace docs build",
+    "docs:dev": "yarn workspace docs dev",
+    "docs:start": "yarn workspace docs start",
     "packlint": "packlint sort -R",
     "publint": "publint --strict",
     "test": "vitest run --coverage --typecheck",
     "test:watch": "vitest --ui --coverage --typecheck",
-    "typecheck": "tsc --noEmit",
-    "docs:dev": "yarn workspace docs dev",
-    "docs:build": "yarn workspace docs build",
-    "docs:start": "yarn workspace docs start",
-    "bench": "vitest bench"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",

--- a/package.json
+++ b/package.json
@@ -44,18 +44,18 @@
   ],
   "scripts": {
     "attw": "attw --pack",
-    "bench": "vitest bench",
     "build": "tsup",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version",
-    "docs:build": "yarn workspace docs build",
-    "docs:dev": "yarn workspace docs dev",
-    "docs:start": "yarn workspace docs start",
     "packlint": "packlint sort -R",
     "publint": "publint --strict",
     "test": "vitest run --coverage --typecheck",
     "test:watch": "vitest --ui --coverage --typecheck",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "docs:dev": "yarn workspace docs dev",
+    "docs:build": "yarn workspace docs build",
+    "docs:start": "yarn workspace docs start",
+    "bench": "vitest bench"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",

--- a/src/josa/josa.ts
+++ b/src/josa/josa.ts
@@ -37,7 +37,7 @@ function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOpt
   }
 
   const has받침 = hasBatchim(word);
-  let index = has받침 ? 0 : 1;
+  const index = has받침 ? 0 : 1;
 
   if (josa === '와/과') {
     return josa.split('/')[has받침 ? 1 : 0] as ExtractJosaOption<T>;

--- a/src/josa/josa.ts
+++ b/src/josa/josa.ts
@@ -17,7 +17,7 @@ type JosaOption =
   | '으로부터/로부터'
   | '이라/라';
 
-const 로_조사: JosaOption[] = ['으로/로', '으로서/로서', '으로써/로써', '으로부터/로부터'];
+const 로_조사 = new Set<JosaOption>(['으로/로', '으로서/로서', '으로써/로써', '으로부터/로부터']);
 
 type ExtractJosaOption<T> = T extends `${infer A}/${infer B}` ? A | B : never;
 
@@ -39,18 +39,22 @@ function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOpt
   const has받침 = hasBatchim(word);
   let index = has받침 ? 0 : 1;
 
-  const is종성ㄹ = has받침 && disassembleCompleteCharacter(word[word.length - 1])?.jongseong === 'ㄹ';
-
-  const isCaseOf로 = has받침 && is종성ㄹ && 로_조사.includes(josa);
-
-  if (josa === '와/과' || isCaseOf로) {
-    index = index === 0 ? 1 : 0;
+  if (josa === '와/과') {
+    return josa.split('/')[has받침 ? 1 : 0];
   }
 
-  const isEndsWith이 = word[word.length - 1] === '이';
+  const 마지막글자 = word[word.length - 1];
+  const isEndsWith이 = 마지막글자 === '이';
 
   if (josa === '이에요/예요' && isEndsWith이) {
-    index = 1;
+    return josa.split('/')[1];
+  }
+
+  const is종성ㄹ = has받침 && disassembleCompleteCharacter(마지막글자)?.jongseong === 'ㄹ';
+  const isCaseOf로 = has받침 && is종성ㄹ && 로_조사.has(josa);
+
+  if (isCaseOf로) {
+    return josa.split('/')[has받침 ? 1 : 0];
   }
 
   return josa.split('/')[index] as ExtractJosaOption<T>;

--- a/src/josa/josa.ts
+++ b/src/josa/josa.ts
@@ -37,7 +37,6 @@ function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOpt
   }
 
   const has받침 = hasBatchim(word);
-  const index = has받침 ? 0 : 1;
 
   if (josa === '와/과') {
     return josa.split('/')[has받침 ? 1 : 0] as ExtractJosaOption<T>;
@@ -57,5 +56,5 @@ function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOpt
     return josa.split('/')[has받침 ? 1 : 0] as ExtractJosaOption<T>;
   }
 
-  return josa.split('/')[index] as ExtractJosaOption<T>;
+  return josa.split('/')[has받침 ? 0 : 1] as ExtractJosaOption<T>;
 }

--- a/src/josa/josa.ts
+++ b/src/josa/josa.ts
@@ -40,21 +40,21 @@ function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOpt
   let index = has받침 ? 0 : 1;
 
   if (josa === '와/과') {
-    return josa.split('/')[has받침 ? 1 : 0];
+    return josa.split('/')[has받침 ? 1 : 0] as ExtractJosaOption<T>;
   }
 
   const 마지막글자 = word[word.length - 1];
   const isEndsWith이 = 마지막글자 === '이';
 
   if (josa === '이에요/예요' && isEndsWith이) {
-    return josa.split('/')[1];
+    return josa.split('/')[1] as ExtractJosaOption<T>;
   }
 
   const is종성ㄹ = has받침 && disassembleCompleteCharacter(마지막글자)?.jongseong === 'ㄹ';
   const isCaseOf로 = has받침 && is종성ㄹ && 로_조사.has(josa);
 
   if (isCaseOf로) {
-    return josa.split('/')[has받침 ? 1 : 0];
+    return josa.split('/')[has받침 ? 1 : 0] as ExtractJosaOption<T>;
   }
 
   return josa.split('/')[index] as ExtractJosaOption<T>;


### PR DESCRIPTION
## Overview

1. 분기 순서를 변경하더라도 로직엔 영향을 주지 않아 간단한 분기에서 early return 하도록 변경하였습니다.
2. 로 조사를 Set으로 변경하여 O(1)로 시간복잡도를 최적화하였습니다.
3. index = index === 0 ? 1 : 0로 분기하던 부분들을 has받침을 사용하도록 수정하였습니다.

## PR Checklist

- [ ] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
