### PR TITLE
docs: es-hangul의 빠름을 보여줄 수 있는 벤치마크 페이지를 만듭니다.

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,7 +9,6 @@
     "auto-josa": "^1.0.0",
     "es-hangul": "workspace:^",
     "esbuild": "0.23.0",
-    "hangul-js": "^0.2.6",
     "josa": "^3.0.1",
     "vitest": "^2.1.2"
   },

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -9,12 +9,11 @@
     "auto-josa": "^1.0.0",
     "es-hangul": "workspace:^",
     "esbuild": "0.23.0",
+    "hangul-js": "^0.2.6",
     "josa": "^3.0.1",
-    "k-popo": "^2.0.5",
     "vitest": "^2.1.2"
   },
   "devDependencies": {
     "@types/josa": "^3"
-  },
-  "version": null
+  }
 }

--- a/benchmarks/performance/josa.bench.ts
+++ b/benchmarks/performance/josa.bench.ts
@@ -3,7 +3,6 @@ import { fakerKO as faker } from '@faker-js/faker';
 import { josa as autoJosa } from 'auto-josa';
 import { josa as esHangulJosa } from 'es-hangul';
 import { josa } from 'josa';
-import { ko } from 'k-popo';
 import { bench, describe } from 'vitest';
 
 const name = faker.person.firstName();
@@ -19,10 +18,6 @@ describe('하나의 조사', () => {
 
   bench('josa', () => {
     josa(`${name}#{이}`);
-  });
-
-  bench('k-popo', () => {
-    ko`${name}(이)가`;
   });
 });
 
@@ -50,12 +45,5 @@ describe(`네개의 조사 ${name}이/가 ${noun}을/를 ${city}은/는 ${street
     josa(`${name}#{을}`);
     josa(`${city}#{은}`);
     josa(`${street}#{와}`);
-  });
-
-  bench('k-popo', () => {
-    ko`${noun}(이)가`;
-    ko`${name}(을)를`;
-    ko`${city}(은)는`;
-    ko`${street}(와)과`;
   });
 });

--- a/docs/src/pages/docs/introduction.en.mdx
+++ b/docs/src/pages/docs/introduction.en.mdx
@@ -81,6 +81,13 @@ const sentence2 = josa(word2, '이/가') + ' 맛있습니다.';
 console.log(sentence2); // '바나나가 맛있습니다.'
 ```
 
+### Fast 
+
+
+es-hangul boasts **top-notch performance**, efficiently handling complex tasks such as Korean character composition and decomposition with incredible speed.
+[Benchmark tests]('./technical/benchmark') against other libraries have shown that es-hangul delivers **overwhelmingly superior performance**.
+
+
 <Callout type="info">
 
 If you have a good idea for handling Hangul well, please let us know. [Suggest a feature via GitHub Issue](https://github.com/toss/es-hangul/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml&title=%5BFeature%5D%3A)

--- a/docs/src/pages/docs/introduction.ko.mdx
+++ b/docs/src/pages/docs/introduction.ko.mdx
@@ -80,6 +80,14 @@ const sentence2 = josa(word2, '이/가') + ' 맛있습니다.';
 console.log(sentence2); // '바나나가 맛있습니다.'
 ```
 
+
+### 매우 빠릅니다
+
+`es-hangul`은 **한글 조합** 및 **분해** 같은 복잡한 작업을 놀라운 속도로 수행하는 **최고의 성능**을 자랑합니다.<br/>
+다른 라이브러리와의 [벤치마크](./technical/benchmark) 테스트 결과, `es-hangul`이 **압도적으로 빠른 성능**을 보여주었습니다
+
+
+
 <Callout type="info">
 
 한글을 잘 다루기 위한 좋은 아이디어가 있다면 알려주세요. [GitHub Issue로 기능 제안하기](https://github.com/toss/es-hangul/issues/new?assignees=&labels=feature&projects=&template=feature_request.yml&title=%5BFeature%5D%3A)

--- a/docs/src/pages/docs/technical/benchmark-bar-chart.tsx
+++ b/docs/src/pages/docs/technical/benchmark-bar-chart.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react';
+
+const ANIMATION_THRESHOLD = 0.3;
+
+interface BenchmarkBarChart {
+  locale: 'ko' | 'en';
+}
+
+export const BenchmarkBarChart = ({ locale }: BenchmarkBarChart) => {
+  const [filledPercentages, setFilledPercentages] = useState<number[]>(benchmarkData.map(() => 0));
+  const [isVisible, setIsVisible] = useState(false);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.intersectionRatio >= ANIMATION_THRESHOLD) {
+          setIsVisible(true);
+        }
+      },
+      { threshold: ANIMATION_THRESHOLD }
+    );
+
+    if (chartRef.current) {
+      observer.observe(chartRef.current);
+    }
+
+    return () => {
+      if (chartRef.current) {
+        observer.unobserve(chartRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const maximum = Math.max(...benchmarkData.map(data => data.operationsPerSecond));
+
+    if (isVisible) {
+      setFilledPercentages(benchmarkData.map(data => (data.operationsPerSecond / maximum) * 100));
+    }
+  }, [isVisible]);
+
+  const isKorean = locale === 'ko';
+
+  return (
+    <div
+      ref={chartRef}
+      className="flex flex-col items-center w-full p-6 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md"
+    >
+      <h1 className="text-3xl font-bold mb-8 text-center text-gray-900 dark:text-gray-100">
+        <span className="text-blue-600 dark:text-blue-400">Lightning Fast</span>
+      </h1>
+
+      <div className="space-y-3 w-full max-w-xl">
+        {benchmarkData.map((data, index) => (
+          <div key={data.name} className="flex flex-col">
+            <div className="flex justify-between items-center mb-1">
+              <span
+                className={`text-lg font-medium ${
+                  data.status === 'fastest' ? 'text-blue-600 dark:text-blue-400' : 'text-gray-800 dark:text-gray-300'
+                }`}
+              >
+                {data.name}
+              </span>
+
+              {data.name === 'es-hangul' && (
+                <span className="text-sm text-green-500">fastest</span> // status는 es-hangul에만 표시
+              )}
+            </div>
+            <div className="relative h-4 bg-gray-300 dark:bg-gray-700 rounded-full overflow-hidden">
+              <div
+                className={`absolute top-0 left-0 h-full rounded-full ${
+                  data.name === 'es-hangul'
+                    ? 'bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500'
+                    : 'bg-blue-200'
+                }`}
+                style={{
+                  width: `${filledPercentages[index]}%`,
+                  transition: 'width 1.5s ease-in-out',
+                }}
+              ></div>
+            </div>
+            <div className="flex justify-between mt-2 text-sm text-gray-600 dark:text-gray-400">
+              {isKorean ? (
+                <>
+                  <span>작업 처리량: {data.operationsPerSecond.toLocaleString()} ops/sec</span>
+                  <span>1000만 건 처리 시간: {data.timeToProcess}초</span>
+                </>
+              ) : (
+                <>
+                  <span>Throughput: {data.operationsPerSecond.toLocaleString()} ops/sec</span>
+                  <span>Processing time for 10 million records: {data.timeToProcess} seconds</span>
+                </>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mt-4 mb-4 italic">
+        {isKorean ? '* josa 함수를 기준으로 측정하였습니다.' : '* Measurements were based on the `josa` function.'}
+      </p>
+
+      <a
+        href="https://github.com/toss/es-hangul/tree/main/benchmarks"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="relative mt-8 px-6 py-3 rounded-full text-white text-lg font-semibold shadow-md transition-all duration-200 group"
+      >
+        <span
+          className="absolute inset-2 rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 
+    opacity-75 blur-sm group-hover:blur-md group-hover:opacity-100 transition-all duration-300"
+          aria-hidden="true"
+        ></span>
+        <span
+          className="relative block px-8 py-3 bg-gray-800 rounded-full text-white dark:bg-gray-700
+    group-hover:bg-gradient-to-r group-hover:from-blue-600 group-hover:via-purple-600 group-hover:to-pink-600 transition-all duration-300"
+        >
+          {isKorean ? '더 자세한 벤치마크 결과 보기' : 'See more detailed benchmark results'}
+        </span>
+      </a>
+    </div>
+  );
+};
+
+const 천만 = 10000000;
+const benchmarkData = [
+  {
+    name: 'es-hangul',
+    operationsPerSecond: 11199038,
+    timeToProcess: (천만 / 11199038).toFixed(2),
+    status: 'fastest',
+  },
+  {
+    name: 'auto-josa',
+    operationsPerSecond: 8512551,
+    timeToProcess: (천만 / 8512551).toFixed(2),
+  },
+  {
+    name: 'josa',
+    operationsPerSecond: 3334947,
+    timeToProcess: (천만 / 3334947).toFixed(2),
+  },
+];

--- a/docs/src/pages/docs/technical/benchmark.en.mdx
+++ b/docs/src/pages/docs/technical/benchmark.en.mdx
@@ -1,0 +1,17 @@
+---
+title: benchamark
+---
+
+import { BenchmarkBarChart } from './benchmark-bar-chart.tsx';
+
+
+# ⚡ Fast Korean Text Processing Library
+
+
+es-hangul boasts **top-notch performance**, efficiently handling complex tasks such as Korean character composition and decomposition with incredible speed.
+Benchmark tests against other libraries have shown that es-hangul delivers **overwhelmingly superior performance**.
+
+<br />
+<br />
+
+<BenchmarkBarChart locale='en'/>

--- a/docs/src/pages/docs/technical/benchmark.ko.mdx
+++ b/docs/src/pages/docs/technical/benchmark.ko.mdx
@@ -1,0 +1,16 @@
+---
+title: benchamark
+---
+
+import { BenchmarkBarChart } from './benchmark-bar-chart.tsx';
+
+
+# ⚡ 빠른 한글 처리 라이브러리
+
+`es-hangul`은 **한글 조합** 및 **분해** 같은 복잡한 작업을 놀라운 속도로 수행하는 **최고의 성능**을 자랑합니다.<br/>
+다른 라이브러리와의 벤치마크 테스트 결과, `es-hangul`이 **압도적으로 빠른 성능**을 보여주었습니다
+
+<br />
+<br />
+
+<BenchmarkBarChart locale="ko"/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3649,8 +3649,8 @@ __metadata:
     auto-josa: "npm:^1.0.0"
     es-hangul: "workspace:^"
     esbuild: "npm:0.23.0"
+    hangul-js: "npm:^0.2.6"
     josa: "npm:^3.0.1"
-    k-popo: "npm:^2.0.5"
     vitest: "npm:^2.1.2"
   languageName: unknown
   linkType: soft
@@ -7050,6 +7050,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hangul-js@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "hangul-js@npm:0.2.6"
+  checksum: 10c0/3bfd2cbbaeef5f42f9cf887a7f458d305d9b84dc087c7988a95a507ccfb60ff97bb13ec5fe0c0f59227333fb56b650be6137228903291b671516cc99bbac6310
+  languageName: node
+  linkType: hard
+
 "har-schema@npm:^2.0.0":
   version: 2.0.0
   resolution: "har-schema@npm:2.0.0"
@@ -8323,13 +8330,6 @@ __metadata:
     object.assign: "npm:^4.1.4"
     object.values: "npm:^1.1.6"
   checksum: 10c0/a32679e9cb55469cb6d8bbc863f7d631b2c98b7fc7bf172629261751a6e7bc8da6ae374ddb74d5fbd8b06cf0eb4572287b259813d92b36e384024ed35e4c13e1
-  languageName: node
-  linkType: hard
-
-"k-popo@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "k-popo@npm:2.0.5"
-  checksum: 10c0/00e0e84bf04edf5cd61859891c210ed82b5cacc4546dc7302bb708a7409d648b38814ec3b791c2994ccf3f23285e1c88622af0d21614d39b4667a3d49640ba62
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3649,7 +3649,6 @@ __metadata:
     auto-josa: "npm:^1.0.0"
     es-hangul: "workspace:^"
     esbuild: "npm:0.23.0"
-    hangul-js: "npm:^0.2.6"
     josa: "npm:^3.0.1"
     vitest: "npm:^2.1.2"
   languageName: unknown
@@ -7047,13 +7046,6 @@ __metadata:
     section-matter: "npm:^1.0.0"
     strip-bom-string: "npm:^1.0.0"
   checksum: 10c0/e38489906dad4f162ca01e0dcbdbed96d1a53740cef446b9bf76d80bec66fa799af07776a18077aee642346c5e1365ed95e4c91854a12bf40ba0d4fb43a625a6
-  languageName: node
-  linkType: hard
-
-"hangul-js@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "hangul-js@npm:0.2.6"
-  checksum: 10c0/3bfd2cbbaeef5f42f9cf887a7f458d305d9b84dc087c7988a95a507ccfb60ff97bb13ec5fe0c0f59227333fb56b650be6137228903291b671516cc99bbac6310
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

fix: #284 

https://github.com/user-attachments/assets/d9526ed5-d8aa-4d1c-9cef-5375b663e974


이번 PR은 es-hangul의 벤치마크 결과를 보다 시각적이고 정보를 효과적으로 전달할 수 있도록 개선하는 내용을 포함하고 있습니다. 업데이트된 벤치마크 차트를 통해 es-hangul이 다른 라이브러리와 비교했을 때 압도적인 성능 우위를 강조합니다.

1.	벤치마크 차트
	•	React를 사용해 es-hangul, auto-josa, josa의 성능 비교를 시각적으로 표현한 벤치마크 차트 추가.
	•	스크롤 시 차트 애니메이션으로 성능 차이를 강조.
2.	언어 로컬라이제이션
	•	주요 UI 요소와 벤치마크 정보를 영어로 번역해 국제 사용자들도 이해할 수 있도록 개선.
3.	네비게이션 업데이트
	•	“더 자세한 벤치마크 결과 보기” 버튼을 클릭 시 GitHub 벤치마크 페이지가 새 탭에서 열리도록 수정.
4.	MDX 문서 추가
	•	es-hangul의 장점과 성능을 효과적으로 전달하기 위한 MDX 파일 추가.
	•	벤치마크 결과 및 이미지를 포함하여 사용자들에게 신뢰감을 줄 수 있는 내용을 작성.


## 왜 중요한가요?

es-hangul은 높은 성능을 자랑하는 라이브러리로, 이를 개발자들에게 제대로 소구하는 것이 중요합니다. 이번 업데이트는 es-hangul의 신뢰성과 성능 우수성을 강조해 더 많은 개발자들이 이 라이브러리를 사용할 수 있도록 돕습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
