### PR TITLE
fix: iOS에서 동영상이 자동으로 전체화면으로 전환되는 현상 제거

### DIFF
--- a/docs/src/pages/docs/advantages/type-support-table.tsx
+++ b/docs/src/pages/docs/advantages/type-support-table.tsx
@@ -106,7 +106,7 @@ export default function TypeSupportTable({ locale }: TypeSupportTableProps) {
           {isKorean ? 'es-hangul의 강력한 타입 시스템' : 'The powerful type system of es-hangul'}
         </figcaption>
 
-        <video className="rounded-lg" width="100%" autoPlay muted preload="metadata" loop>
+        <video className="rounded-lg" width="100%" autoPlay muted preload="metadata" loop playsInline>
           <source src="/videos/type_support.mp4" type="video/mp4"></source>
         </video>
       </figure>


### PR DESCRIPTION
## Overview

ASIS.

https://github.com/user-attachments/assets/55cf0d3d-847e-4932-8388-f82dd1c08155


TOBE.

https://github.com/user-attachments/assets/d9242b54-ca16-463c-a41e-b44a640c00c1


iOS에서 동영상이 autoplay 기능을 제공할 경우 자동으로 전체화면으로 전환되는 현상을 제거합니다.

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
