### PR TITLE
chore: numberToHangul 테스트 커버리지 보강

### DIFF
--- a/src/numberToHangul/numberToHangul.spec.ts
+++ b/src/numberToHangul/numberToHangul.spec.ts
@@ -40,4 +40,11 @@ describe('numberToHangul', () => {
     expect(numberToHangul(1_234)).toBe('천이백삼십사');
     expect(numberToHangul(9_999)).toBe('구천구백구십구');
   });
+
+  test('유효하지 않은 숫자에 대한 오류 처리', () => {
+    expect(() => numberToHangul(-1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangul(-12345)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangul(NaN)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangul(Infinity)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+  });
 });

--- a/src/numberToHangul/numberToHangul.ts
+++ b/src/numberToHangul/numberToHangul.ts
@@ -1,6 +1,10 @@
 import { HANGUL_CARDINAL, HANGUL_DIGITS, HANGUL_NUMBERS } from '@/_internal/constants';
 
 export function numberToHangul(input: number, options?: { spacing?: boolean }): string {
+  if (!Number.isFinite(input) || Number.isNaN(input) || !Number.isInteger(input) || input < 0) {
+    throw new Error('유효한 0 이상의 정수를 입력해주세요.');
+  }
+
   if (input === 0) {
     return '영';
   }
@@ -11,6 +15,7 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
 
   while (remainingDigits.length > 0) {
     const currentPart = remainingDigits.slice(-4);
+    console.log('currentPart: ', currentPart);
 
     koreanParts.unshift(`${numberToKoreanUpToThousand(Number(currentPart))}${HANGUL_DIGITS[placeIndex]}`);
 
@@ -29,10 +34,6 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
 }
 
 function numberToKoreanUpToThousand(num: number): string {
-  if (num < 0 || num > 9999) {
-    throw new Error('0 이상 9999 이하의 숫자만 입력 가능합니다.');
-  }
-
   const koreanDigits = num
     .toString()
     .split('')
@@ -42,5 +43,4 @@ function numberToKoreanUpToThousand(num: number): string {
     .join('');
 
   return koreanDigits.replace(/일천/, '천').replace(/일백/, '백').replace(/일십/, '십') || '';
-
 }

--- a/src/numberToHangul/numberToHangul.ts
+++ b/src/numberToHangul/numberToHangul.ts
@@ -15,7 +15,6 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
 
   while (remainingDigits.length > 0) {
     const currentPart = remainingDigits.slice(-4);
-    console.log('currentPart: ', currentPart);
 
     koreanParts.unshift(`${numberToKoreanUpToThousand(Number(currentPart))}${HANGUL_DIGITS[placeIndex]}`);
 


### PR DESCRIPTION
## Overview

ASIS.
<img width="628" alt="image" src="https://github.com/user-attachments/assets/f4036012-f0f1-4826-ac54-c929292c704f">

TOBE.
<img width="640" alt="image" src="https://github.com/user-attachments/assets/ef716e8c-f017-482a-8d47-a38cdfbd3793">

유효하지 않은 숫자에 대한 오류 처리 로직을 추가하였습니다. 또한, 내부 로직상 9999가 넘을수가 없어 기존의 에러 던지기는 제거하였습니다.

## PR Checklist

- [X] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
