### PR TITLE
feat: combineVowels 리턴 타입 보강

### DIFF
--- a/src/combineVowels/combineVowels.ts
+++ b/src/combineVowels/combineVowels.ts
@@ -17,9 +17,11 @@ import { DISASSEMBLED_VOWELS_BY_VOWEL } from '@/_internal/constants';
  * combineVowels('ㅗ', 'ㅐ') // 'ㅙ'
  * combineVowels('ㅗ', 'ㅛ') // 'ㅗㅛ'
  */
-export function combineVowels(vowel1: string, vowel2: string) {
-  return (
-    Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(([, value]) => value === `${vowel1}${vowel2}`)?.[0] ??
-    `${vowel1}${vowel2}`
-  );
+
+type Invert<T extends Record<string, string>> = { [K in keyof T as T[K]]: K };
+type CombineVowel = Invert<typeof DISASSEMBLED_VOWELS_BY_VOWEL>;
+
+export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
+  return (Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(([, value]) => value === `${vowel1}${vowel2}`)?.[0] ??
+    `${vowel1}${vowel2}`) as `${V1}${V2}` extends keyof CombineVowel ? CombineVowel[`${V1}${V2}`] : `${V1}${V2}`;
 }


### PR DESCRIPTION
## Overview

<img src="https://github.com/user-attachments/assets/374bf5c9-457c-4042-b120-e7e7bfcdd2f3" width="600px" />
<img src="https://github.com/user-attachments/assets/c8b69e6f-a534-4900-970d-30b6313f562a" width="600px" />

`combineVowels`의 리턴타입을 제네릭을 통해 type-narrowing 하도록 개선합니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
