### PR TITLE
fix: numberToHangul로 큰 숫자 변환시 불필요한 단위 제거

### DIFF
--- a/src/numberToHangul/numberToHangul.spec.ts
+++ b/src/numberToHangul/numberToHangul.spec.ts
@@ -5,6 +5,8 @@ describe('numberToHangul', () => {
     expect(numberToHangul(210_000)).toBe('이십일만');
     expect(numberToHangul(12_345)).toBe('일만이천삼백사십오');
     expect(numberToHangul(123_456_780)).toBe('일억이천삼백사십오만육천칠백팔십');
+    expect(numberToHangul(100_000_000)).toBe('일억');
+    expect(numberToHangul(1_000_000_000_000)).toBe('일조');
   });
 
   test('공백 포함 변환', () => {

--- a/src/numberToHangul/numberToHangul.ts
+++ b/src/numberToHangul/numberToHangul.ts
@@ -16,7 +16,10 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
   while (remainingDigits.length > 0) {
     const currentPart = remainingDigits.slice(-4);
 
-    koreanParts.unshift(`${numberToKoreanUpToThousand(Number(currentPart))}${HANGUL_DIGITS[placeIndex]}`);
+    const koreanNumber = numberToKoreanUpToThousand(Number(currentPart));
+    if (koreanNumber !== '') {
+      koreanParts.unshift(`${koreanNumber}${HANGUL_DIGITS[placeIndex]}`);
+    }
 
     remainingDigits = remainingDigits.slice(0, -4);
     placeIndex++;


### PR DESCRIPTION
## Overview

1. numberToHangul을 이용하여 1억 이상의 숫자를 변환할 때 불필요한 단위가 붙어서 출력되는 버그를 수정했습니다.
2. 이를 검증 할 수 있는 테스트를 추가했습니다.

resolved #311

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
