### PR TITLE
fix: numberToHangulMixed 및 numberToHangul에 모든 number 처리

### DIFF
--- a/.changeset/tender-bugs-judge.md
+++ b/.changeset/tender-bugs-judge.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+fix: numberToHangulMixed 및 numberToHangul에 모든 number 처리

--- a/docs/src/pages/docs/api/numberToHangul.en.mdx
+++ b/docs/src/pages/docs/api/numberToHangul.en.mdx
@@ -19,6 +19,7 @@ function numberToHangul(input: number, options?: { spacing?: boolean }): string;
 numberToHangul(210_000); // '이십일만';
 numberToHangul(12_345); // '일만이천삼백사십오';
 numberToHangul(123_456_780); // '일억이천삼백사십오만육천칠백팔십';
+numberToHangulMixed(-12_345.678); // '마이너스일만이천삼백사십오점육칠팔';
 numberToHangul(123_456_780, { spacing: true }); // '일억 이천삼백사십오만 육천칠백팔십';
 ```
 

--- a/docs/src/pages/docs/api/numberToHangul.ko.mdx
+++ b/docs/src/pages/docs/api/numberToHangul.ko.mdx
@@ -19,6 +19,7 @@ function numberToHangul(input: number, options?: { spacing?: boolean }): string;
 numberToHangul(210_000); // '이십일만';
 numberToHangul(12_345); // '일만이천삼백사십오';
 numberToHangul(123_456_780); // '일억이천삼백사십오만육천칠백팔십';
+numberToHangulMixed(-12_345.678); // '마이너스일만이천삼백사십오점육칠팔';
 numberToHangul(123_456_780, { spacing: true }); // '일억 이천삼백사십오만 육천칠백팔십';
 ```
 

--- a/docs/src/pages/docs/api/numberToHangulMixed.en.mdx
+++ b/docs/src/pages/docs/api/numberToHangulMixed.en.mdx
@@ -6,8 +6,8 @@ import { Sandpack } from '@/components/Sandpack';
 
 # numberToHangulMixed
 
-Attaches the Korean number units that change every 4 digits to the given number.
-It supports spacing for “man(萬)” units to accommodate various requirements.
+For numbers provided as integers, it automatically appends Korean numerical units that change every four digits,
+and it supports spacing based on the 'man(萬)' unit to meet various requirements.
 
 ```typescript
 function numberToHangulMixed(input: number, options?: { spacing?: boolean }): string;

--- a/docs/src/pages/docs/api/numberToHangulMixed.en.mdx
+++ b/docs/src/pages/docs/api/numberToHangulMixed.en.mdx
@@ -6,7 +6,7 @@ import { Sandpack } from '@/components/Sandpack';
 
 # numberToHangulMixed
 
-For numbers provided as integers, it automatically appends Korean numerical units that change every four digits,
+For the given numbers, it automatically appends Korean numerical units that change every four digits,
 and it supports spacing based on the 'man(萬)' unit to meet various requirements.
 
 ```typescript
@@ -19,6 +19,7 @@ function numberToHangulMixed(input: number, options?: { spacing?: boolean }): st
 numberToHangulMixed(210_000); // '21만';
 numberToHangulMixed(12_345); // '1만2,345';
 numberToHangulMixed(123_456_780); // '1억2,345만6,780';
+numberToHangulMixed(-12_345.678); // '-1만2,345.678';
 numberToHangulMixed(123_456_780, { spacing: true }); // '1억 2,345만 6,780';
 ```
 

--- a/docs/src/pages/docs/api/numberToHangulMixed.ko.mdx
+++ b/docs/src/pages/docs/api/numberToHangulMixed.ko.mdx
@@ -6,8 +6,8 @@ import { Sandpack } from '@/components/Sandpack';
 
 # numberToHangulMixed
 
-정수로 주어진 숫자에 한해 4자리마다 달라지는 한글의 숫자 단위를 자동으로 붙여주며,
-다양한 요구 사항에 맞춰 ‘만(萬)’ 단위 기준으로 띄어쓰기도 지원합니다.
+주어진 숫자에 대해 4자리마다 달라지는 한글의 숫자 단위를 자동으로 붙여주며,
+다양한 요구 사항에 맞춰 '만(萬)' 단위 기준으로 띄어쓰기도 지원합니다.
 
 ```typescript
 function numberToHangulMixed(input: number, options?: { spacing?: boolean }): string;
@@ -19,6 +19,7 @@ function numberToHangulMixed(input: number, options?: { spacing?: boolean }): st
 numberToHangulMixed(210_000); // '21만';
 numberToHangulMixed(12_345); // '1만2,345';
 numberToHangulMixed(123_456_780); // '1억2,345만6,780';
+numberToHangulMixed(-12_345.678); // '-1만2,345.678';
 numberToHangulMixed(123_456_780, { spacing: true }); // '1억 2,345만 6,780';
 ```
 

--- a/docs/src/pages/docs/api/numberToHangulMixed.ko.mdx
+++ b/docs/src/pages/docs/api/numberToHangulMixed.ko.mdx
@@ -6,8 +6,8 @@ import { Sandpack } from '@/components/Sandpack';
 
 # numberToHangulMixed
 
-주어진 숫자에 **4자리 마다 바뀌는 한글의 숫자 단위**를 붙여줍니다.
-다양한 요구사항에 대응하도록 '만(萬)' 단위로 띄어쓰기를 지원합니다.
+정수로 주어진 숫자에 한해 4자리마다 달라지는 한글의 숫자 단위를 자동으로 붙여주며,
+다양한 요구 사항에 맞춰 ‘만(萬)’ 단위 기준으로 띄어쓰기도 지원합니다.
 
 ```typescript
 function numberToHangulMixed(input: number, options?: { spacing?: boolean }): string;

--- a/src/numberToHangul/numberToHangul.spec.ts
+++ b/src/numberToHangul/numberToHangul.spec.ts
@@ -48,5 +48,8 @@ describe('numberToHangul', () => {
     expect(() => numberToHangul(-12345)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
     expect(() => numberToHangul(NaN)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
     expect(() => numberToHangul(Infinity)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangul(0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangul(12345.678)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangul(-0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
   });
 });

--- a/src/numberToHangul/numberToHangul.spec.ts
+++ b/src/numberToHangul/numberToHangul.spec.ts
@@ -15,7 +15,7 @@ describe('numberToHangul', () => {
     expect(numberToHangul(123_456_780, { spacing: true })).toBe('일억 이천삼백사십오만 육천칠백팔십');
   });
 
-  test('0과 10,000보다 작은 경우', () => {
+  test('0 이상 10,000 미만인 경우', () => {
     expect(numberToHangul(0)).toBe('영');
     expect(numberToHangul(1)).toBe('일');
     expect(numberToHangul(2)).toBe('이');
@@ -43,13 +43,34 @@ describe('numberToHangul', () => {
     expect(numberToHangul(9_999)).toBe('구천구백구십구');
   });
 
-  test('유효하지 않은 숫자에 대한 오류 처리', () => {
-    expect(() => numberToHangul(-1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangul(-12345)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangul(NaN)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangul(Infinity)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangul(0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangul(12345.678)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangul(-0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+  test('음수', () => {
+    expect(numberToHangul(-210_000)).toBe('마이너스이십일만');
+    expect(numberToHangul(-12_345)).toBe('마이너스일만이천삼백사십오');
+    expect(numberToHangul(-123_456_780)).toBe('마이너스일억이천삼백사십오만육천칠백팔십');
+    expect(numberToHangul(-210_000, { spacing: true })).toBe('마이너스 이십일만');
+    expect(numberToHangul(-12_345, { spacing: true })).toBe('마이너스 일만 이천삼백사십오');
+    expect(numberToHangul(-123_456_780, { spacing: true })).toBe('마이너스 일억 이천삼백사십오만 육천칠백팔십');
+  });
+
+  test('Infinity', () => {
+    expect(numberToHangul(Infinity)).toBe('무한대');
+    expect(numberToHangul(-Infinity)).toBe('마이너스무한대');
+    expect(numberToHangul(-Infinity, { spacing: true })).toBe('마이너스 무한대');
+  });
+
+  test('소수', () => {
+    expect(numberToHangul(0.1)).toBe('영점일');
+    expect(numberToHangul(12_345.678)).toBe('일만이천삼백사십오점육칠팔');
+    expect(numberToHangul(-0.1)).toBe('마이너스영점일');
+    expect(numberToHangul(-12_345.678)).toBe('마이너스일만이천삼백사십오점육칠팔');
+    expect(numberToHangul(0.1, { spacing: true })).toBe('영점 일');
+    expect(numberToHangul(12_345.678, { spacing: true })).toBe('일만 이천삼백사십오점 육칠팔');
+    expect(numberToHangul(-0.1, { spacing: true })).toBe('마이너스 영점 일');
+    expect(numberToHangul(-12_345.678, { spacing: true })).toBe('마이너스 일만 이천삼백사십오점 육칠팔');
+  });
+
+  test('유효하지 않은 입력에 대한 오류 처리', () => {
+    expect(() => numberToHangul(NaN)).toThrow('유효한 숫자를 입력해주세요.');
+    expect(() => numberToHangul('123' as unknown as number)).toThrow('유효한 숫자를 입력해주세요.');
   });
 });

--- a/src/numberToHangul/numberToHangul.ts
+++ b/src/numberToHangul/numberToHangul.ts
@@ -16,11 +16,9 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
   }
 
   const isNegative = input < 0;
-  if (isNegative) {
-    input = Math.abs(input);
-  }
+  const absoluteInput = Math.abs(input);
 
-  const [integerPart, decimalPart] = input.toString().split('.');
+  const [integerPart, decimalPart] = absoluteInput.toString().split('.');
 
   const koreanParts: string[] = [];
   let remainingDigits = integerPart;
@@ -56,7 +54,10 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
     result += options?.spacing ? '점 ' + decimalKorean : '점' + decimalKorean;
   }
 
-  return isNegative ? (options?.spacing ? '마이너스 ' + result : '마이너스' + result) : result;
+  if (isNegative) {
+    result = options?.spacing ? `마이너스 ${result}` : `마이너스${result}`;
+  }
+  return result;
 }
 
 function numberToKoreanUpToThousand(num: number): string {

--- a/src/numberToHangul/numberToHangul.ts
+++ b/src/numberToHangul/numberToHangul.ts
@@ -1,16 +1,29 @@
 import { HANGUL_CARDINAL, HANGUL_DIGITS, HANGUL_NUMBERS } from '@/_internal/constants';
 
 export function numberToHangul(input: number, options?: { spacing?: boolean }): string {
-  if (!Number.isFinite(input) || Number.isNaN(input) || !Number.isInteger(input) || input < 0) {
-    throw new Error('유효한 0 이상의 정수를 입력해주세요.');
+  if (typeof input !== 'number' || Number.isNaN(input)) {
+    throw new Error('유효한 숫자를 입력해주세요.');
   }
 
+  if (input === Infinity) {
+    return '무한대';
+  }
+  if (input === -Infinity) {
+    return options?.spacing ? '마이너스 무한대' : '마이너스무한대';
+  }
   if (input === 0) {
     return '영';
   }
 
+  const isNegative = input < 0;
+  if (isNegative) {
+    input = Math.abs(input);
+  }
+
+  const [integerPart, decimalPart] = input.toString().split('.');
+
   const koreanParts: string[] = [];
-  let remainingDigits = input.toString();
+  let remainingDigits = integerPart;
   let placeIndex = 0;
 
   while (remainingDigits.length > 0) {
@@ -25,14 +38,25 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
     placeIndex++;
   }
 
-  if (options?.spacing) {
-    return koreanParts
-      .filter(part => part !== '')
-      .join(' ')
-      .trim();
+  let result = koreanParts
+    .filter(part => part !== '')
+    .join(options?.spacing ? ' ' : '')
+    .trim();
+
+  if (integerPart === '0') {
+    result = '영';
   }
 
-  return koreanParts.join('');
+  if (decimalPart) {
+    const decimalKorean = decimalPart
+      .split('')
+      .map(digit => HANGUL_NUMBERS[Number(digit)])
+      .join('');
+
+    result += options?.spacing ? '점 ' + decimalKorean : '점' + decimalKorean;
+  }
+
+  return isNegative ? (options?.spacing ? '마이너스 ' + result : '마이너스' + result) : result;
 }
 
 function numberToKoreanUpToThousand(num: number): string {

--- a/src/numberToHangulMixed/numberToHangulMixed.spec.ts
+++ b/src/numberToHangulMixed/numberToHangulMixed.spec.ts
@@ -13,7 +13,7 @@ describe('numberToHangulMixed', () => {
     expect(numberToHangulMixed(123_456_780, { spacing: true })).toBe('1억 2,345만 6,780');
   });
 
-  test('0과 10,000보다 작은 경우', () => {
+  test('0 이상 10,000 미만인 경우', () => {
     expect(numberToHangulMixed(0)).toBe('0');
     expect(numberToHangulMixed(1)).toBe('1');
     expect(numberToHangulMixed(2)).toBe('2');
@@ -41,13 +41,34 @@ describe('numberToHangulMixed', () => {
     expect(numberToHangulMixed(9_999)).toBe('9,999');
   });
 
-  test('유효하지 않은 숫자에 대한 오류 처리', () => {
-    expect(() => numberToHangulMixed(-1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangulMixed(-12345)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangulMixed(NaN)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangulMixed(Infinity)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangulMixed(0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangulMixed(12345.678)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
-    expect(() => numberToHangulMixed(-0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+  test('음수', () => {
+    expect(numberToHangulMixed(-210_000)).toBe('-21만');
+    expect(numberToHangulMixed(-12_345)).toBe('-1만2,345');
+    expect(numberToHangulMixed(-123_456_780)).toBe('-1억2,345만6,780');
+    expect(numberToHangulMixed(-210_000, { spacing: true })).toBe('-21만');
+    expect(numberToHangulMixed(-12_345, { spacing: true })).toBe('-1만 2,345');
+    expect(numberToHangulMixed(-123_456_780, { spacing: true })).toBe('-1억 2,345만 6,780');
+  });
+
+  test('Infinity', () => {
+    expect(numberToHangulMixed(Infinity)).toBe('무한대');
+    expect(numberToHangulMixed(-Infinity)).toBe('-무한대');
+    expect(numberToHangulMixed(-Infinity, { spacing: true })).toBe('-무한대');
+  });
+
+  test('소수', () => {
+    expect(numberToHangulMixed(0.1)).toBe('0.1');
+    expect(numberToHangulMixed(12_345.678)).toBe('1만2,345.678');
+    expect(numberToHangulMixed(-0.1)).toBe('-0.1');
+    expect(numberToHangulMixed(-12_345.678)).toBe('-1만2,345.678');
+    expect(numberToHangulMixed(0.1, { spacing: true })).toBe('0.1');
+    expect(numberToHangulMixed(12_345.678, { spacing: true })).toBe('1만 2,345.678');
+    expect(numberToHangulMixed(-0.1, { spacing: true })).toBe('-0.1');
+    expect(numberToHangulMixed(-12_345.678, { spacing: true })).toBe('-1만 2,345.678');
+  });
+
+  test('유효하지 않은 입력에 대한 오류 처리', () => {
+    expect(() => numberToHangulMixed(NaN)).toThrow('유효한 숫자를 입력해주세요.');
+    expect(() => numberToHangulMixed('123' as unknown as number)).toThrow('유효한 숫자를 입력해주세요.');
   });
 });

--- a/src/numberToHangulMixed/numberToHangulMixed.spec.ts
+++ b/src/numberToHangulMixed/numberToHangulMixed.spec.ts
@@ -40,4 +40,14 @@ describe('numberToHangulMixed', () => {
     expect(numberToHangulMixed(1_234)).toBe('1,234');
     expect(numberToHangulMixed(9_999)).toBe('9,999');
   });
+
+  test('유효하지 않은 숫자에 대한 오류 처리', () => {
+    expect(() => numberToHangulMixed(-1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangulMixed(-12345)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangulMixed(NaN)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangulMixed(Infinity)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangulMixed(0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangulMixed(12345.678)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+    expect(() => numberToHangulMixed(-0.1)).toThrow('유효한 0 이상의 정수를 입력해주세요.');
+  });
 });

--- a/src/numberToHangulMixed/numberToHangulMixed.ts
+++ b/src/numberToHangulMixed/numberToHangulMixed.ts
@@ -16,11 +16,9 @@ export function numberToHangulMixed(input: number, options?: { spacing?: boolean
   }
 
   const isNegative = input < 0;
-  if (isNegative) {
-    input = Math.abs(input);
-  }
+  const absoluteInput = Math.abs(input);
 
-  const [integerPart, decimalPart] = input.toString().split('.');
+  const [integerPart, decimalPart] = absoluteInput.toString().split('.');
 
   const koreanParts: string[] = [];
   let remainingDigits = integerPart;

--- a/src/numberToHangulMixed/numberToHangulMixed.ts
+++ b/src/numberToHangulMixed/numberToHangulMixed.ts
@@ -1,16 +1,29 @@
 import { HANGUL_DIGITS } from '@/_internal/constants';
 
 export function numberToHangulMixed(input: number, options?: { spacing?: boolean }): string {
-  if (!Number.isFinite(input) || Number.isNaN(input) || !Number.isInteger(input) || input < 0) {
-    throw new Error('유효한 0 이상의 정수를 입력해주세요.');
+  if (typeof input !== 'number' || Number.isNaN(input)) {
+    throw new Error('유효한 숫자를 입력해주세요.');
   }
 
+  if (input === Infinity) {
+    return '무한대';
+  }
+  if (input === -Infinity) {
+    return '-무한대';
+  }
   if (input === 0) {
     return '0';
   }
 
+  const isNegative = input < 0;
+  if (isNegative) {
+    input = Math.abs(input);
+  }
+
+  const [integerPart, decimalPart] = input.toString().split('.');
+
   const koreanParts: string[] = [];
-  let remainingDigits = input.toString();
+  let remainingDigits = integerPart;
   let placeIndex = 0;
 
   while (remainingDigits.length > 0) {
@@ -26,12 +39,16 @@ export function numberToHangulMixed(input: number, options?: { spacing?: boolean
     placeIndex++;
   }
 
-  if (options?.spacing) {
-    return koreanParts
-      .filter(part => part !== '')
-      .join(' ')
-      .trim();
-  }
+  let result = koreanParts
+    .filter(part => part !== '')
+    .join(options?.spacing ? ' ' : '')
+    .trim();
 
-  return koreanParts.join('');
+  if (integerPart === '0') {
+    result = '0';
+  }
+  if (decimalPart) {
+    result += '.' + decimalPart;
+  }
+  return isNegative ? '-' + result : result;
 }

--- a/src/numberToHangulMixed/numberToHangulMixed.ts
+++ b/src/numberToHangulMixed/numberToHangulMixed.ts
@@ -1,6 +1,10 @@
 import { HANGUL_DIGITS } from '@/_internal/constants';
 
 export function numberToHangulMixed(input: number, options?: { spacing?: boolean }): string {
+  if (!Number.isFinite(input) || Number.isNaN(input) || !Number.isInteger(input) || input < 0) {
+    throw new Error('유효한 0 이상의 정수를 입력해주세요.');
+  }
+
   if (input === 0) {
     return '0';
   }

--- a/src/seosusa/seosusa.ts
+++ b/src/seosusa/seosusa.ts
@@ -32,7 +32,7 @@ import { SEOSUSA_MAP, SEOSUSA_SPECIAL_CASE_MAP } from './constants';
  * @see https://es-hangul.slash.page/docs/api/seosusa
  */
 export function seosusa(num: number): string {
-  if (num === 0 || !Number.isInteger(num)) {
+  if (num <= 0 || !Number.isInteger(num)) {
     throw new Error('유효하지 않은 입력입니다. 1이상의 정수만 지원합니다.');
   }
 


### PR DESCRIPTION
## Overview

`numberToHangulMixed` 및 `numberToHangul`가 양의 정수 뿐만 아니라 소수, 음수, 무한대 또한 처리할 수 있게 수정하였습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
