### PR TITLE
docs: amountToHangul 문서에 deprecated 표시

### DIFF
--- a/docs/src/pages/docs/api/amountToHangul.en.mdx
+++ b/docs/src/pages/docs/api/amountToHangul.en.mdx
@@ -6,7 +6,7 @@ import { Sandpack } from '@/components/Sandpack';
 
 # amountToHangul
 
-> **⚠️ Deprecated: Please use the more flexible `numberToHangul` instead.**
+> **⚠️ Deprecated: Please use the more flexible [`numberToHangul`](./numberToHangul) instead.**
 
 Converts numeric amounts to the Korean reading of the [National Institute of Korean Language](https://ko.dict.naver.com/#/correct/korean/info?seq=602) rules.
 

--- a/docs/src/pages/docs/api/amountToHangul.en.mdx
+++ b/docs/src/pages/docs/api/amountToHangul.en.mdx
@@ -3,10 +3,13 @@ title: amountToHangul
 ---
 
 import { Sandpack } from '@/components/Sandpack';
+import { Callout } from 'nextra/components';
 
 # amountToHangul
 
-> **⚠️ Deprecated: Please use the more flexible [`numberToHangul`](./numberToHangul) instead.**
+<Callout type="error" emoji="⚠️">
+  Deprecated: Please use the more flexible [`numberToHangul`](./numberToHangul) instead.
+</Callout>
 
 Converts numeric amounts to the Korean reading of the [National Institute of Korean Language](https://ko.dict.naver.com/#/correct/korean/info?seq=602) rules.
 

--- a/docs/src/pages/docs/api/amountToHangul.en.mdx
+++ b/docs/src/pages/docs/api/amountToHangul.en.mdx
@@ -6,6 +6,8 @@ import { Sandpack } from '@/components/Sandpack';
 
 # amountToHangul
 
+> **⚠️ Deprecated: Please use the more flexible `numberToHangul` instead.**
+
 Converts numeric amounts to the Korean reading of the [National Institute of Korean Language](https://ko.dict.naver.com/#/correct/korean/info?seq=602) rules.
 
 For detailed examples, see below.

--- a/docs/src/pages/docs/api/amountToHangul.ko.mdx
+++ b/docs/src/pages/docs/api/amountToHangul.ko.mdx
@@ -6,7 +6,7 @@ import { Sandpack } from '@/components/Sandpack';
 
 # amountToHangul
 
-> **⚠️ Deprecated: 더 유연하게 사용 가능한 `numberToHangul`을 이용해 주세요.**
+> **⚠️ Deprecated: 더 유연하게 사용 가능한 [`numberToHangul`](./numberToHangul)을 이용해 주세요.**
 
 숫자나 문자를 [국립국어원](https://ko.dict.naver.com/#/correct/korean/info?seq=602) 규칙의 한글 읽기 문자열로 변환합니다.
 

--- a/docs/src/pages/docs/api/amountToHangul.ko.mdx
+++ b/docs/src/pages/docs/api/amountToHangul.ko.mdx
@@ -3,10 +3,13 @@ title: amountToHangul
 ---
 
 import { Sandpack } from '@/components/Sandpack';
+import { Callout } from 'nextra/components';
 
 # amountToHangul
 
-> **⚠️ Deprecated: 더 유연하게 사용 가능한 [`numberToHangul`](./numberToHangul)을 이용해 주세요.**
+<Callout type="error" emoji="⚠️">
+  Deprecated: 더 유연하게 사용 가능한 [`numberToHangul`](./numberToHangul)을 이용해 주세요.
+</Callout>
 
 숫자나 문자를 [국립국어원](https://ko.dict.naver.com/#/correct/korean/info?seq=602) 규칙의 한글 읽기 문자열로 변환합니다.
 

--- a/docs/src/pages/docs/api/amountToHangul.ko.mdx
+++ b/docs/src/pages/docs/api/amountToHangul.ko.mdx
@@ -6,6 +6,8 @@ import { Sandpack } from '@/components/Sandpack';
 
 # amountToHangul
 
+> **⚠️ Deprecated: 더 유연하게 사용 가능한 `numberToHangul`을 이용해 주세요.**
+
 숫자나 문자를 [국립국어원](https://ko.dict.naver.com/#/correct/korean/info?seq=602) 규칙의 한글 읽기 문자열로 변환합니다.
 
 자세한 예시는 아래 Example을 참고하세요.


### PR DESCRIPTION
## Overview

related issue: #321 

영문 및 한글 문서 모두에 deprecation 경고를 추가했습니다.

함수 JSDoc의 문구를 이용했습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
