### PR TITLE
feat: canBeJungseong 함수가 분리되지 않은 이중모음도 중성으로 인식하도록 개선합니다.

### DIFF
--- a/src/_internal/constants.ts
+++ b/src/_internal/constants.ts
@@ -97,7 +97,16 @@ export const CHOSEONGS = [
 /**
  * 중성으로 올 수 있는 한글 글자
  */
-export const JUNSEONGS = Object.values(DISASSEMBLED_VOWELS_BY_VOWEL);
+export const JUNSEONGS = [
+  ...Object.values(DISASSEMBLED_VOWELS_BY_VOWEL),
+  'ㅘ',
+  'ㅙ',
+  'ㅚ',
+  'ㅝ',
+  'ㅞ',
+  'ㅟ',
+  'ㅢ',
+] as const;
 
 /**
  * 종성으로 올 수 있는 한글 글자

--- a/src/canBeJungseong/canBeJungseong.spec.ts
+++ b/src/canBeJungseong/canBeJungseong.spec.ts
@@ -5,6 +5,9 @@ describe('canBeJungseong', () => {
     it('ㅗㅏ', () => {
       expect(canBeJungseong('ㅗㅏ')).toBe(true);
     });
+    it('ㅘ', () => {
+      expect(canBeJungseong('ㅘ')).toBe(true);
+    });
     it('ㅏ', () => {
       expect(canBeJungseong('ㅏ')).toBe(true);
     });

--- a/src/canBeJungseong/canBeJungseong.ts
+++ b/src/canBeJungseong/canBeJungseong.ts
@@ -14,6 +14,7 @@ import { JUNSEONGS } from '@/_internal/constants';
  * @example
  * canBeJungseong('ㅏ') // true
  * canBeJungseong('ㅗㅏ') // true
+ * canBeJungseong('ㅘ') // true
  * canBeJungseong('ㅏㅗ') // false
  * canBeJungseong('ㄱ') // false
  * canBeJungseong('ㄱㅅ') // false


### PR DESCRIPTION
## Overview

`canBeJungseong` 함수가 인수로 `ㅔ`,`ㅖ`,`ㅖ`,`ㅒ`를 제외한 이중모음(이하 **복합모음**)을 받을 때, 모음이 분리되어 있지 않다면 이를 중성으로 인식하지 않습니다.

```js
canBeJungseong('ㅗㅏ') // true
canBeJungseong('ㅘ')  // false
```

따라서 복합모음을 `canBeJungseong`의 인수로 넘겨줄 때는 모음을 분리해서 넘겨줘야 하는데, 다음과 같은 이유로 다소 불편하다고 느껴졌습니다.

---

#### 1. 복합 모음을 분리해서 인수로 넘겨주는 방식이 직관적이지 않음

`ㅗㅏ`와 같이 분리된 형태보다는 `ㅘ`와 같이 합쳐진 형태로 인수를 넘기는 것이 더 직관적이라고 생각됩니다.

#### 2. 키보드에서 복합모음을 분리해서 작성하는 것이 불편

 맥OS와 윈도우는 복합모음 입력 시 다음과 같이 자동으로 분리되어 있는 모음을 하나로 합쳐줍니다.

![composite_vowels](https://github.com/user-attachments/assets/2d66936d-6c8f-4580-8714-0b716cadf4a1)
> 

합쳐지는 것을 막으려면 아래 영상과 같이 첫 모음 입력 후 다음 모음을 입력하기 전에 **한 칸 띄워줘야 하는 불편함**이 있습니다.

![output](https://github.com/user-attachments/assets/ee0d91b7-7356-4418-9b17-83ed728143f1)


---


따라서 복합모음 또한 종성으로 인식할 수 있도록, 배열 `JUNSEONGS`에 값을 추가하였습니다.



```js
canBeJungseong('ㅗㅏ') // true
canBeJungseong('ㅘ')  // true
```


## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
