### PR TITLE
docs: 존재하지 않는 `josa` url 수정 

### DIFF
--- a/docs/src/pages/docs/api/core/josa.pick.en.mdx
+++ b/docs/src/pages/docs/api/core/josa.pick.en.mdx
@@ -6,7 +6,7 @@ import { Sandpack } from '@/components/Sandpack';
 
 # josa.pick
 
-The josa.pick method selects and returns the appropriate Korean particle based on a given Korean string and particle options. This method is used within the [josa](https://es-hangul.slash.page/en/docs/api/josa) function, and the form of the particle is determined by the last character of the string.
+The josa.pick method selects and returns the appropriate Korean particle based on a given Korean string and particle options. This method is used within the [josa](https://es-hangul.slash.page/en/docs/api/core/josa) function, and the form of the particle is determined by the last character of the string.
 
 ```typescript
 function josa.pick(

--- a/docs/src/pages/docs/api/core/josa.pick.ko.mdx
+++ b/docs/src/pages/docs/api/core/josa.pick.ko.mdx
@@ -6,7 +6,7 @@ import { Sandpack } from '@/components/Sandpack';
 
 # josa.pick
 
-`josa.pick` 메서드는 주어진 한글 문자열과 조사 옵션에 따라 적절한 조사를 선택하여 반환합니다. 이 메서드는 [josa](https://es-hangul.slash.page/docs/api/josa) 함수 내에서 사용되며, 문자열의 마지막 글자에 따라 조사의 형태가 결정됩니다.
+`josa.pick` 메서드는 주어진 한글 문자열과 조사 옵션에 따라 적절한 조사를 선택하여 반환합니다. 이 메서드는 [josa](https://es-hangul.slash.page/docs/api/core/josa) 함수 내에서 사용되며, 문자열의 마지막 글자에 따라 조사의 형태가 결정됩니다.
 
 ```typescript
 function josa.pick(


### PR DESCRIPTION
## Overview

공식 문서에서 `api/core/josa.pick`에서 

"이 메서드는 [josa](https://es-hangul.slash.page/docs/api/josa) 함수 내에서 사용되며, 문자열의 마지막 글자에 따라 조사의 형태가 결정됩니다."

이 곳에서 존재하지 않은 `josa` url을 수정했어요.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
