### PR TITLE
fix: 사이드바 번역 파일에서 trailing comma 제거

### DIFF
--- a/docs/src/pages/docs/_meta.en.json
+++ b/docs/src/pages/docs/_meta.en.json
@@ -1,12 +1,12 @@
 {
   "introduction": "Introduction",
   "installation": "Installation",
+  "advantages": "Advantages",
   "api": {
     "title": "Usage",
     "theme": {
       "collapsed": false
     }
   },
-  "advantages": "Advantages",
-  "migration": "Migration",
+  "migration": "Migration"
 }

--- a/docs/src/pages/docs/_meta.ko.json
+++ b/docs/src/pages/docs/_meta.ko.json
@@ -1,12 +1,12 @@
 {
   "introduction": "소개",
   "installation": "설치하기",
+  "advantages": "이점",
   "api": {
     "title": "API",
     "theme": {
       "collapsed": false
     }
   },
-  "advantages": "이점",
-  "migration": "마이그레이션",
+  "migration": "마이그레이션"
 }


### PR DESCRIPTION
## Overview

#345 에서 `_meta.en.json`과 `_meta.ko.json`에서 trailing comma를 제거하지 않아 본 docs에 제대로 적용이 되지 않았어요. 
trailing comma를 제거함으로써 제대로 반영됩니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
