### PR TITLE
fix: 로마자 표기법에 의거하여 한글 자모 변수명을 수정합니다.

### DIFF
--- a/src/core/removeLastCharacter/removeLastCharacter.ts
+++ b/src/core/removeLastCharacter/removeLastCharacter.ts
@@ -39,9 +39,9 @@ export function removeLastCharacter(words: string) {
 
       return first;
     } else {
-      const [first, firstJungsung, secondJungsung, firstJongsung] = lastCharacterWithoutLastAlphabet;
+      const [first, firstJungseong, secondJungseong, firstJongseong] = lastCharacterWithoutLastAlphabet;
 
-      return combineCharacter(first, `${firstJungsung}${secondJungsung}`, firstJongsung);
+      return combineCharacter(first, `${firstJungseong}${secondJungseong}`, firstJongseong);
     }
   })();
 


### PR DESCRIPTION
## Overview

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->
 
 로마자 표기법에 따르면 "성"은 `sung`이 아닌 `seong`으로 표기되어야 하므로 이에 맞게 변수명을 수정했어요.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
