### PR TITLE
fix:  '이에요/예요' 조사에서 '이'로 끝나는 단어에 대한 불필요한 예외 제거

### DIFF
--- a/src/core/josa/josa.ts
+++ b/src/core/josa/josa.ts
@@ -47,11 +47,5 @@ function josaPicker<T extends JosaOption>(word: string, josa: T): ExtractJosaOpt
     index = index === 0 ? 1 : 0;
   }
 
-  const isEndsWith이 = word[word.length - 1] === '이';
-
-  if (josa === '이에요/예요' && isEndsWith이) {
-    index = 1;
-  }
-
   return josa.split('/')[index] as ExtractJosaOption<T>;
 }


### PR DESCRIPTION
## Overview

이 PR은 `josa.ts` 파일에서 '이에요/예요' 조사의 선택 기준에 포함된 불필요한 예외 처리 로직을 제거합니다. 기존 로직은 단어가 '이'로 끝나는 경우 무조건 '예요'를 선택하도록 되어 있었으나, 이는 문법적으로 올바르지 않습니다. '이에요/예요'는 단어의 마지막 글자의 받침 유무만을 기준으로 선택되어야 하며, '이'로 끝나는 단어라도 받침이 있으면 '이에요', 없으면 '예요'가 맞습니다.

마지막 글자가 '이'로 끝나면 '-예요'를 선택하게 되는 현재의 로직은 문제를 해결하는 것에 대해서는 문제가 없지만 그 과정에 불필요한 연산이 발생합니다.
'이'로 끝난다는 것은 받침이 없다는 것을 의미하고 위의 코드가 없더라도 정상적으로 작동됩니다.

Resolved #348 

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
