### PR TITLE
seosusa 함수의 테스트 커버리지를 100%로 개선

### DIFF
--- a/src/number/seosusa/seosusa.spec.ts
+++ b/src/number/seosusa/seosusa.spec.ts
@@ -1,4 +1,5 @@
 import { seosusa } from './seosusa';
+import * as numberToHangulModule from '@/number/numberToHangul';
 
 describe('seosusa', () => {
   const validNumbers = [
@@ -39,6 +40,19 @@ describe('seosusa', () => {
   invalidNumbers.forEach(num => {
     it(`${num} - 유효하지 않은 숫자에 대해 오류를 발생시켜야 한다.`, () => {
       expect(() => seosusa(num)).toThrow('유효하지 않은 입력입니다. 1이상의 정수만 지원합니다.');
+    });
+  });
+
+  describe('에러 처리', () => {
+    it('numberToHangul에서 에러가 발생하면 적절한 에러 메시지를 반환한다', () => {
+      const mockNumberToHangul = vi.spyOn(numberToHangulModule, 'numberToHangul');
+      mockNumberToHangul.mockImplementation(() => {
+        throw new Error('Mock error from numberToHangul');
+      });
+
+      expect(() => seosusa(100)).toThrow('유효하지 않은 입력입니다. 1이상의 정수만 지원합니다.');
+
+      mockNumberToHangul.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Overview

seosusa 함수의 테스트 커버리지를 92.85%에서 100%로 개선했습니다. 기존에 커버되지 않았던 numberToHangul 에러 처리 로직에 대한 테스트를 추가했습니다.

### 변경사항

- src/number/seosusa/seosusa.spec.ts에 에러 처리 테스트 케이스 추가
- vi.spyOn을 사용하여 numberToHangul 함수를 mock하고 의도적으로 에러를 발생시켜 catch 블록 테스트
- 테스트 커버리지 100% 달성

### 테스트
`yarn test src/number/seosusa/seosusa.spec.ts`

#### 변경 전
<img width="442" alt="스크린샷 2025-05-26 오후 3 13 21" src="https://github.com/user-attachments/assets/e63634ee-73dd-42e2-9d14-d88e167e01fb" />

#### 변경 후
<img width="438" alt="스크린샷 2025-05-26 오후 3 13 48" src="https://github.com/user-attachments/assets/8581931a-c9a8-4c45-90e7-b5aa37f0a6e5" />

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
