### PR TITLE
docs: reliability 페이지의 테스트 커버리지 테이블이 비어있는 문제 해결

### DIFF
--- a/docs/src/pages/docs/advantages/reliability.tsx
+++ b/docs/src/pages/docs/advantages/reliability.tsx
@@ -16,8 +16,8 @@ export default function Reliability({ locale }: TypeSupportTableProps) {
   const { total: totalCoverage, ...fileEntries } = coverageJSON;
 
   const isValidFilePath = (filePath: string): boolean => {
-    // src 뒤 2-depth까지의 경로를 필터링하며, anything.something.ts 등의 명칭을 가진 파일들은 반환되지 않도록 `.ts`로 끝나되 추가 점(`.`)이 없는 경우만 허용
-    const regex = /\/src\/[^/]+\/[^/]+(?<!\..+)\.ts$/;
+    // src 뒤 3-depth까지의 경로를 필터링하며, anything.something.ts 등의 명칭을 가진 파일들은 반환되지 않도록 `.ts`로 끝나되 추가 점(`.`)이 없는 경우만 허용
+    const regex = /\/src\/[^/]+\/[^/]+\/[^/]+(?<!\..+)\.ts$/;
 
     return regex.test(filePath) && !filePath.endsWith('constants.ts') && !filePath.includes('_internal');
   };
@@ -26,13 +26,19 @@ export default function Reliability({ locale }: TypeSupportTableProps) {
     return filePath.split('/').pop()?.split('.')[0];
   };
 
+  const extractCategory = (filePath: string): string | undefined => {
+    // src 다음의 첫번째 디렉토리 이름 추출
+    const match = filePath.match(/\/src\/([^/]+)\//);
+    return match ? match[1] : undefined;
+  };
+
   const filterValidFileEntries = (coverageFileEntries: typeof fileEntries) => {
     return Object.entries(coverageFileEntries)
       .filter(([filePath]) => isValidFilePath(filePath))
       .flatMap(([filePath, info]) => {
-        const filename = extractFileName(filePath);
-
-        return filename != null ? [[filename, info] as const] : [];
+        const fileName = extractFileName(filePath);
+        const category = extractCategory(filePath);
+        return fileName != null && category != null ? [[fileName, category, info] as const] : [];
       });
   };
 
@@ -142,10 +148,10 @@ export default function Reliability({ locale }: TypeSupportTableProps) {
           </thead>
 
           <tbody>
-            {filterValidFileEntries(fileEntries).map(([filename, info]) => (
-              <tr key={filename} className="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+            {filterValidFileEntries(fileEntries).map(([fileName, category, info]) => (
+              <tr key={fileName} className="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
                 <th scope="row" className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
-                  <a href={`../api/${filename}`}>{filename} 🔗</a>
+                  <a href={`../api/${category}/${fileName}`}>{fileName} 🔗</a>
                 </th>
 
                 <td className="px-6 py-4">✅ ({info.statements.pct}%)</td>


### PR DESCRIPTION
## Overview

### 문제 상황

reliability 페이지의 테스트 커버리지 표가 아래와 같이 비어있는 문제가 발생해요.
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/259e41e8-5fca-4cfd-ad1a-212daf7f504f" />

### 문제 원인

- 테이블 관련 작업이 이루어진 PR(#302) 당시에는 API 파일들이 모두 src 디렉토리 바로 아래에 위치했지만, 이후 `core`, `keyboard` 등의 카테고리 디렉토리가 추가되었어요.
- 파일 경로 validate 로직이 이 변경사항을 반영하지 않아, 대부분의 파일이 필터링되면서 테이블이 비게 되었어요.

### 변경 사항

- `src/카테고리/서브폴더/파일.ts` 구조를 인식하도록 정규식을 수정했어요.
- 파일의 상위 디렉토리를 추출해 링크 경로(`../api/카테고리/파일`)도 이에 맞게 수정했어요.
- `filename`이라는 변수명을 camelCase에 맞춰 `fileName`으로 변경했어요.

https://github.com/user-attachments/assets/d8b6722e-8384-4361-86ee-aa57458cab4f


## PR Checklist
- [x] I read and included these actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
