### PR TITLE
fix: numberToHangul 소수점 아래 변환 시 "영" 이 생략되는 문제를 수정합니다

### DIFF
--- a/.changeset/tame-wolves-end.md
+++ b/.changeset/tame-wolves-end.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+fix: numberToHangul 소수점 아래 변환 시 "영" 이 생략되는 문제를 수정합니다

--- a/src/number/numberToHangul/numberToHangul.spec.ts
+++ b/src/number/numberToHangul/numberToHangul.spec.ts
@@ -63,6 +63,7 @@ describe('numberToHangul', () => {
     expect(numberToHangul(12_345.678)).toBe('일만이천삼백사십오점육칠팔');
     expect(numberToHangul(-0.1)).toBe('마이너스영점일');
     expect(numberToHangul(-12_345.678)).toBe('마이너스일만이천삼백사십오점육칠팔');
+    expect(numberToHangul(0.0102)).toEqual('영점영일영이');
     expect(numberToHangul(0.1, { spacing: true })).toBe('영점 일');
     expect(numberToHangul(12_345.678, { spacing: true })).toBe('일만 이천삼백사십오점 육칠팔');
     expect(numberToHangul(-0.1, { spacing: true })).toBe('마이너스 영점 일');

--- a/src/number/numberToHangul/numberToHangul.ts
+++ b/src/number/numberToHangul/numberToHangul.ts
@@ -1,4 +1,4 @@
-import { HANGUL_CARDINAL, HANGUL_DIGITS, HANGUL_NUMBERS } from '@/_internal/constants';
+import { HANGUL_CARDINAL, HANGUL_DIGITS, HANGUL_NUMBERS, HANGUL_NUMBERS_FOR_DECIMAL } from '@/_internal/constants';
 
 export function numberToHangul(input: number, options?: { spacing?: boolean }): string {
   if (typeof input !== 'number' || Number.isNaN(input)) {
@@ -48,7 +48,7 @@ export function numberToHangul(input: number, options?: { spacing?: boolean }): 
   if (decimalPart) {
     const decimalKorean = decimalPart
       .split('')
-      .map(digit => HANGUL_NUMBERS[Number(digit)])
+      .map(digit => HANGUL_NUMBERS_FOR_DECIMAL[Number(digit)])
       .join('');
 
     result += options?.spacing ? '점 ' + decimalKorean : '점' + decimalKorean;


### PR DESCRIPTION
## Overview
1. `numberToHangul` 함수의 소수점 아래 변환 시 "영" 이 생략되는 문제를 수정합니다.
```
// AS-IS
console.log(numberToHangul(0.0102)); // "영점일이"

// TO-BE
console.log(numberToHangul(0.0102)); // "영점영일영이"
```

2. `numberToHangul.spec` '소수' 테스트에 `0.0102` 검증을 추가합니다

```
expect(numberToHangul(0.0102)).toEqual('영점영일영이');
```

<!--
        이 PR이 무엇에 관한 것인지 명확하고 간결하게 설명해주세요.
 -->

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
