### PR TITLE
fix: JUNSEONGS 상수명을 JUNGSEONGS로 수정

### DIFF
--- a/src/_internal/constants.ts
+++ b/src/_internal/constants.ts
@@ -97,7 +97,7 @@ export const CHOSEONGS = [
 /**
  * 중성으로 올 수 있는 한글 글자
  */
-export const JUNSEONGS = Object.values(DISASSEMBLED_VOWELS_BY_VOWEL);
+export const JUNGSEONGS = Object.values(DISASSEMBLED_VOWELS_BY_VOWEL);
 
 /**
  * 종성으로 올 수 있는 한글 글자

--- a/src/core/canBeJungseong/canBeJungseong.ts
+++ b/src/core/canBeJungseong/canBeJungseong.ts
@@ -1,5 +1,5 @@
 import { hasValueInReadOnlyStringList } from '@/_internal';
-import { DISASSEMBLED_VOWELS_BY_VOWEL, JUNSEONGS } from '@/_internal/constants';
+import { DISASSEMBLED_VOWELS_BY_VOWEL, JUNGSEONGS } from '@/_internal/constants';
 
 /**
  * @name canBeJungseong
@@ -20,7 +20,7 @@ import { DISASSEMBLED_VOWELS_BY_VOWEL, JUNSEONGS } from '@/_internal/constants';
  * canBeJungseong('ㄱㅅ') // false
  * canBeJungseong('가') // false
  */
-export function canBeJungseong(character: string): character is (typeof JUNSEONGS)[number] {
+export function canBeJungseong(character: string): character is (typeof JUNGSEONGS)[number] {
   if (!character) {
     return false;
   }
@@ -31,5 +31,5 @@ export function canBeJungseong(character: string): character is (typeof JUNSEONG
   }
 
   // 분해된 이중모음 문자인 경우 (ㅗㅏ, ㅜㅓ 등)
-  return hasValueInReadOnlyStringList(JUNSEONGS, character);
+  return hasValueInReadOnlyStringList(JUNGSEONGS, character);
 }

--- a/src/core/combineCharacter/combineCharacter.ts
+++ b/src/core/combineCharacter/combineCharacter.ts
@@ -1,4 +1,4 @@
-import { CHOSEONGS, COMPLETE_HANGUL_START_CHARCODE, JONGSEONGS, JUNSEONGS } from '@/_internal/constants';
+import { CHOSEONGS, COMPLETE_HANGUL_START_CHARCODE, JONGSEONGS, JUNGSEONGS } from '@/_internal/constants';
 import { canBeChoseong } from '@/core/canBeChoseong';
 import { canBeJongseong } from '@/core/canBeJongseong';
 import { canBeJungseong } from '@/core/canBeJungseong';
@@ -26,11 +26,11 @@ export function combineCharacter(choseong: string, jungseong: string, jongseong 
     throw new Error(`Invalid hangul Characters: ${choseong}, ${jungseong}, ${jongseong}`);
   }
 
-  const numOfJungseongs = JUNSEONGS.length;
+  const numOfJungseongs = JUNGSEONGS.length;
   const numOfJongseongs = JONGSEONGS.length;
 
   const choseongIndex = CHOSEONGS.indexOf(choseong as (typeof CHOSEONGS)[number]);
-  const jungseongIndex = JUNSEONGS.indexOf(jungseong as (typeof JUNSEONGS)[number]);
+  const jungseongIndex = JUNGSEONGS.indexOf(jungseong as (typeof JUNGSEONGS)[number]);
   const jongseongIndex = JONGSEONGS.indexOf(jongseong as (typeof JONGSEONGS)[number]);
 
   const choseongOfTargetConsonant = choseongIndex * numOfJungseongs * numOfJongseongs;

--- a/src/core/disassembleCompleteCharacter/disassembleCompleteCharacter.ts
+++ b/src/core/disassembleCompleteCharacter/disassembleCompleteCharacter.ts
@@ -3,14 +3,14 @@ import {
   COMPLETE_HANGUL_END_CHARCODE,
   COMPLETE_HANGUL_START_CHARCODE,
   JONGSEONGS,
-  JUNSEONGS,
+  JUNGSEONGS,
   NUMBER_OF_JONGSEONG,
   NUMBER_OF_JUNGSEONG,
 } from '@/_internal/constants';
 
 interface ReturnTypeDisassembleCompleteCharacter {
   choseong: (typeof CHOSEONGS)[number];
-  jungseong: (typeof JUNSEONGS)[number];
+  jungseong: (typeof JUNGSEONGS)[number];
   jongseong: (typeof JONGSEONGS)[number];
 }
 
@@ -45,7 +45,7 @@ export function disassembleCompleteCharacter(letter: string): ReturnTypeDisassem
 
   return {
     choseong: CHOSEONGS[choseongIndex],
-    jungseong: JUNSEONGS[jungseongIndex],
+    jungseong: JUNGSEONGS[jungseongIndex],
     jongseong: JONGSEONGS[jongseongIndex],
   } as const;
 }


### PR DESCRIPTION
## Overview

한국어 표기법에 맞게 **중성** 상수명을 수정했습니다. 기존 `JUNSEONGS`를 올바른 표기인 `JUNGSEONGS`로 변경하여 프로젝트 전체의 명명 일관성을 유지했습니다.

**변경 사항:**
- `constants.ts` : JUNSEONGS → JUNGSEONGS로 수정
- 프로젝트 내 다른 파일들에서는 이미 jungseong 표기를 사용 중
- 기존 CHOSEONGS(초성), JONGSEONGS(종성)과 명명 일관성 유지
- 한국어에서 중성은 "중성(中聲)"이므로 JUNGSEONG이 표준 표기

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
