### PR TITLE
feat: 종성, 중성 추출 함수 추가

### DIFF
--- a/docs/src/pages/docs/api/core/getJongseong.en.mdx
+++ b/docs/src/pages/docs/api/core/getJongseong.en.mdx
@@ -1,0 +1,41 @@
+---
+title: getJongseong
+---
+
+import { Sandpack } from '@/components/Sandpack';
+
+# getJongseong
+
+Extracts the Jongseong (final consonants) from a Korean word. (Example: 별 -> 'ㄹ')
+
+```typescript
+function getJongseong(
+  // Korean string from which to extract the jongseong
+  word: string
+): string;
+```
+
+## Examples
+
+```tsx
+getJongseong('별');        // 'ㄹ'
+getJongseong('하늘');      // 'ㄹ'
+getJongseong('띄어 쓰기'); // ' '
+getJongseong('파이팅');    // 'ㅇ'
+```
+
+## Demo
+
+<br />
+
+<Sandpack>
+
+```ts index.ts
+import { getJongseong } from 'es-hangul';
+
+console.log(getJongseong('별'));
+```
+
+</Sandpack>
+
+

--- a/docs/src/pages/docs/api/core/getJongseong.ko.mdx
+++ b/docs/src/pages/docs/api/core/getJongseong.ko.mdx
@@ -1,0 +1,43 @@
+---
+title: getJongseong
+---
+
+import { Sandpack } from '@/components/Sandpack';
+
+# getJongseong
+
+단어에서 종성을 추출합니다. (예: `별` -> `'ㄹ'`)
+
+자세한 예시는 아래 Example을 참고하세요.
+
+```typescript
+function getJongseong(
+  // 종성을 추출할 한글 문자열
+  word: string
+): string;
+```
+
+## Examples
+
+```tsx
+getJongseong('별');        // 'ㄹ'
+getJongseong('하늘');      // 'ㄹ'
+getJongseong('띄어 쓰기'); // ' '
+getJongseong('파이팅');    // 'ㅇ'
+```
+
+## 사용해보기
+
+<br />
+
+<Sandpack>
+
+```ts index.ts
+import { getJongseong } from 'es-hangul';
+
+console.log(getJongseong('별'));
+```
+
+</Sandpack>
+
+

--- a/docs/src/pages/docs/api/core/getJungseong.en.mdx
+++ b/docs/src/pages/docs/api/core/getJungseong.en.mdx
@@ -1,0 +1,39 @@
+---
+title: getJungseong
+---
+
+import { Sandpack } from '@/components/Sandpack';
+
+# getJungseong
+
+Extracts the Jungseong (vowels) from a Korean word. (Example: 사과 -> 'ㅏㅘ')
+
+```typescript
+function getJungseong(
+  // Korean string from which to extract the jungseong
+  word: string
+): string;
+```
+
+## Examples
+
+```tsx
+getJungseong('사과');      // 'ㅏㅘ'
+getJungseong('하늘');      // 'ㅏㅡ'
+getJungseong('띄어 쓰기'); // 'ㅢㅓ ㅡㅣ'
+```
+
+## Demo
+
+<br />
+
+<Sandpack>
+
+```ts index.ts
+import { getJungseong } from 'es-hangul';
+
+console.log(getJungseong('사과'));
+```
+
+</Sandpack>
+

--- a/docs/src/pages/docs/api/core/getJungseong.ko.mdx
+++ b/docs/src/pages/docs/api/core/getJungseong.ko.mdx
@@ -1,0 +1,42 @@
+---
+title: getJungseong
+---
+
+import { Sandpack } from '@/components/Sandpack';
+
+# getJungseong
+
+단어에서 중성을 추출합니다. (예: `사과` -> `'ㅏㅘ'`)
+
+자세한 예시는 아래 Example을 참고하세요.
+
+```typescript
+function getJungseong(
+  // 중성을 추출할 한글 문자열
+  word: string
+): string;
+```
+
+## Examples
+
+```tsx
+getJungseong('사과');      // 'ㅏㅘ'
+getJungseong('하늘');      // 'ㅏㅡ'
+getJungseong('띄어 쓰기'); // 'ㅢㅓ ㅡㅣ'
+```
+
+## 사용해보기
+
+<br />
+
+<Sandpack>
+
+```ts index.ts
+import { getJungseong } from 'es-hangul';
+
+console.log(getJungseong('사과'));
+```
+
+</Sandpack>
+
+

--- a/src/core/getJongseong/getJongseong.spec.ts
+++ b/src/core/getJongseong/getJongseong.spec.ts
@@ -1,0 +1,27 @@
+import { getJongseong } from './getJongseong';
+
+describe('getJongseong', () => {
+  it('"값" 단어에서 종성 "ㅄ"을 추출한다.', () => {
+    expect(getJongseong('값')).toBe('ㅄ');
+  });
+  it('"사람" 단어에서 종성 "ㅁ"을 추출한다.', () => {
+    expect(getJongseong('사람')).toBe('ㅁ');
+  });
+  it('"사과" 단어에서 종성 ""을 추출한다.', () => {
+    expect(getJongseong('사과')).toBe('');
+  });
+  it('"ㄴㅈ" 자모 입력에서는 종성 ""을 추출한다.', () => {
+    expect(getJongseong('ㄴㅈ')).toBe('');
+  });
+  it('"리액트" 단어에서 종성 "ㄱ"을 추출한다.', () => {
+    expect(getJongseong('리액트')).toBe('ㄱ');
+  });
+  it('"띄어 쓰기" 문장에서 종성 " "을 추출한다.', () => {
+    expect(getJongseong('띄어 쓰기')).toBe(' ');
+  });
+  it('"파이팅" 단어에서 종성 "ㅇ"을 추출한다.', () => {
+    expect(getJongseong('파이팅')).toBe('ㅇ');
+  });
+});
+
+

--- a/src/core/getJongseong/getJongseong.ts
+++ b/src/core/getJongseong/getJongseong.ts
@@ -1,0 +1,43 @@
+import { DISASSEMBLED_CONSONANTS_BY_CONSONANT, JONGSEONGS } from '@/_internal/constants';
+import { JASO_HANGUL_NFD } from '../getChoseong/constants';
+
+/**
+ * @name getJongseong
+ * @description
+ * 단어에서 종성을 추출합니다. (예: `값` -> `'ㅄ'`, `사과` -> `''`)
+ * ```typescript
+ * getJongseong(
+ *   // 종성을 추출할 단어
+ *   word: string
+ * ): string
+ * ```
+ * @example
+ * getJongseong('값') // 'ㅄ'
+ * getJongseong('사과') // ''
+ */
+export function getJongseong(word: string) {
+  return word
+    .normalize('NFD')
+    .replace(EXTRACT_JONGSEONG_REGEX, '')
+    .replace(
+      CHOOSE_NFD_JONGSEONG_REGEX,
+      $0 => JONGSEONGS_COMPOSITE[$0.charCodeAt(0) - 0x11a8]
+    );
+}
+
+const EXTRACT_JONGSEONG_REGEX = new RegExp(
+  `[^\\u${JASO_HANGUL_NFD.START_JONGSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_JONGSEONG.toString(16)}\\s]+`,
+  'ug'
+);
+
+const CHOOSE_NFD_JONGSEONG_REGEX = new RegExp(
+  `[\\u${JASO_HANGUL_NFD.START_JONGSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_JONGSEONG.toString(16)}]`,
+  'g'
+);
+
+const JONGSEONGS_COMPOSITE = JONGSEONGS.slice(1).map(
+  d => Object.fromEntries(
+    Object.entries(DISASSEMBLED_CONSONANTS_BY_CONSONANT).map(([key, val]) => [val, key])
+  )[d]
+);
+

--- a/src/core/getJongseong/index.ts
+++ b/src/core/getJongseong/index.ts
@@ -1,0 +1,3 @@
+export * from './getJongseong';
+
+

--- a/src/core/getJungseong/getJungseong.spec.ts
+++ b/src/core/getJungseong/getJungseong.spec.ts
@@ -1,0 +1,22 @@
+import { getJungseong } from './getJungseong';
+
+describe('getJungseong', () => {
+  it('"사과" 단어에서 중성 "ㅏㅘ"을 추출한다.', () => {
+    expect(getJungseong('사과')).toBe('ㅏㅘ');
+  });
+  it('"프론트엔드" 단어에서 중성 "ㅡㅗㅡㅔㅡ"을 추출한다.', () => {
+    expect(getJungseong('프론트엔드')).toBe('ㅡㅗㅡㅔㅡ');
+  });
+  it('"ㅗㅏ" 문자에서 중성 "ㅗㅏ"을 추출한다.', () => {
+    expect(getJungseong('ㅗㅏ')).toBe('ㅗㅏ');
+  });
+  it('"리액트" 단어에서 중성 "ㅣㅐㅡ"을 추출한다.', () => {
+    expect(getJungseong('리액트')).toBe('ㅣㅐㅡ');
+  });
+
+  it('"띄어 쓰기" 문장에서 중성 "ㅢㅓ ㅡㅣ"을 추출한다.', () => {
+    expect(getJungseong('띄어 쓰기')).toBe('ㅢㅓ ㅡㅣ');
+  });
+});
+
+

--- a/src/core/getJungseong/getJungseong.ts
+++ b/src/core/getJungseong/getJungseong.ts
@@ -1,0 +1,36 @@
+import { DISASSEMBLED_VOWELS_BY_VOWEL } from '@/_internal/constants';
+import { JASO_HANGUL_NFD } from '../getChoseong/constants';
+
+/**
+ * @name getJungseong
+ * @description
+ * 단어에서 중성을 추출합니다. (예: `사과` -> `'ㅏㅘ'`)
+ * ```typescript
+ * getJungseong(
+ *   // 중성을 추출할 단어
+ *   word: string
+ * ): string
+ * ```
+ * @example
+ * getJungseong('사과') // 'ㅏㅘ'
+ * getJungseong('띄어 쓰기') // 'ㅢㅓ ㅡㅣ'
+ */
+export function getJungseong(word: string) {
+  return word
+    .normalize('NFD')
+    .replace(EXTRACT_JUNGSEONG_REGEX, '') 
+    .replace(CHOOSE_NFD_JUNGSEONG_REGEX, $0 => JUNGSEONGS_COMPOSITE[$0.charCodeAt(0) - 0x1161]); // NFD -> 합성 중성 문자
+}
+
+const EXTRACT_JUNGSEONG_REGEX = new RegExp(
+  `[^\\u${JASO_HANGUL_NFD.START_JUNGSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_JUNGSEONG.toString(16)}ㅏ-ㅣ\\s]+`,
+  'ug'
+);
+const CHOOSE_NFD_JUNGSEONG_REGEX = new RegExp(
+  `[\\u${JASO_HANGUL_NFD.START_JUNGSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_JUNGSEONG.toString(16)}]`,
+  'g'
+);
+
+const JUNGSEONGS_COMPOSITE = Object.keys(DISASSEMBLED_VOWELS_BY_VOWEL);
+
+

--- a/src/core/getJungseong/index.ts
+++ b/src/core/getJungseong/index.ts
@@ -1,0 +1,4 @@
+export * from './getJungseong';
+
+
+

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,6 +5,8 @@ export { disassembleToGroups } from './disassembleToGroups';
 export { combineCharacter } from './combineCharacter';
 export { combineVowels } from './combineVowels';
 export { getChoseong } from './getChoseong';
+export { getJungseong } from './getJungseong';
+export { getJongseong } from './getJongseong';
 export { canBeChoseong } from './canBeChoseong';
 export { canBeJungseong } from './canBeJungseong';
 export { canBeJongseong } from './canBeJongseong';


### PR DESCRIPTION
## Overview
현재 es-hangul은 getChoseong을 이용하여 초성 추출 API를 제공하고 있습니다.
모든 한글 구성요소의 일관성을 유지하려면 중성(모음) 및 종성(종성) 추출 API도 제공하는 것이 어떨까 합니다.
resolved #365 
``` typescript
getJungseong('사과'); // 'ㅏㅘ'
getJungseong('하늘'); // 'ㅏㅡ'
getJungseong('띄어 쓰기'); // ' ㅢㅓ ㅡㅣ'
```
``` typescript
getJongseong('별');   // 'ㄹ'
getJongseong('하늘'); // 'ㄹ'
getJongseong('띄어 쓰기'); // ' '
getJongseong('파이팅'); // 'ㅇ'
```

## 논의거리
`getChoseong`, `getJungseong`, `getJongseong` 모두 **존재하는 자모만 추출, 공백은 그대로 유지**라는 동일한 규칙을 적용합니다.
그래서 '띄어 쓰기', '파이팅' 이라는 단어에 대해서 현재 다음과 같이 종성을 추출합니다.

- "띄어 쓰기" → 종성이 없고 공백만 존재하므로 " "
- "파이팅" → 종성이 실제로 있는 글자만 남아 "ㅇ"
``` typescript
getJongseong('띄어 쓰기'); // ' '
getJongseong('파이팅'); // 'ㅇ' 
```
하지만 종성 추출에서 "없는 종성"을 어떻게 다룰지는 여러 선택지가 있을 수 있습니다.

- "띄어 쓰기" → "" (아예 생략) 혹은 " " (공백만 유지)
- "파이팅" → " ㅇ" (모든 글자 위치를 유지, 종성이 없는 자리는 빈칸 처리)
``` typescript
getJongseong('띄어 쓰기'); // '' or ' '
getJongseong('파이팅'); // '  ㅇ' 
```
현재는 간결성과 검색/비교 활용성을 우선하여
“존재하는 자모만 추출 + 공백만 유지” 규칙을 채택했지만,
향후 유스케이스에 따라 조정 가능성이 있습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
