### PR TITLE
feat: keepNonHangul 옵션으로 비한글 문자 유지

### DIFF
--- a/.changeset/getchoseong-keep-non-hangul.md
+++ b/.changeset/getchoseong-keep-non-hangul.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+feat: getChoseong에 keepNonHangul 옵션을 추가합니다. true일 때 NFD 중성·종성만 제거하고 숫자·기호 등 비한글 문자를 유지합니다.

--- a/src/core/getChoseong/getChoseong.spec.ts
+++ b/src/core/getChoseong/getChoseong.spec.ts
@@ -17,4 +17,12 @@ describe('getChoseong', () => {
   it('"띄어 쓰기" 문장에서 초성 "ㄸㅇ ㅆㄱ"을 추출한다.', () => {
     expect(getChoseong('띄어 쓰기')).toBe('ㄸㅇ ㅆㄱ');
   });
+
+  it('keepNonHangul이 false이면 숫자 등 비한글을 제거한다.', () => {
+    expect(getChoseong('네이버123')).toBe('ㄴㅇㅂ');
+  });
+
+  it('keepNonHangul이 true이면 숫자 등 비한글을 유지한다.', () => {
+    expect(getChoseong('네이버123', { keepNonHangul: true })).toBe('ㄴㅇㅂ123');
+  });
 });

--- a/src/core/getChoseong/getChoseong.ts
+++ b/src/core/getChoseong/getChoseong.ts
@@ -5,17 +5,25 @@ import { JASO_HANGUL_NFD } from './constants';
  * @name getChoseong
  * @description
  * 단어에서 초성을 추출합니다. (예: `사과` -> `'ㅅㄱ'`)
- * ```typescript
- * getChoseong(
- *   // 초성을 추출할 단어
- *   word: string
- * ): string
- * ```
+ *
+ * `keepNonHangul`이 `true`이면 한글 외 문자(숫자, 영문 등)를 그대로 둡니다.
+ * 기본값은 `false`로, 초성·호환 자모·공백만 남기고 나머지는 제거합니다.
+ *
  * @example
  * getChoseong('사과') // 'ㅅㄱ'
  * getChoseong('띄어 쓰기') // 'ㄸㅇ ㅆㄱ'
+ * getChoseong('네이버123', { keepNonHangul: true }) // 'ㄴㅇㅂ123'
  */
-export function getChoseong(word: string) {
+export function getChoseong(word: string, options: { keepNonHangul?: boolean } = {}) {
+  const { keepNonHangul = false } = options;
+
+  if (keepNonHangul) {
+    return word
+      .normalize('NFD')
+      .replace(REMOVE_NFD_JUNG_JONG_REGEX, '')
+      .replace(CHOOSE_NFD_CHOSEONG_REGEX, $0 => CHOSEONGS[$0.charCodeAt(0) - 0x1100]);
+  }
+
   return word
     .normalize('NFD')
     .replace(EXTRACT_CHOSEONG_REGEX, '') // NFD ㄱ-ㅎ, NFC ㄱ-ㅎ 외 문자 삭제
@@ -29,4 +37,8 @@ const EXTRACT_CHOSEONG_REGEX = new RegExp(
 const CHOOSE_NFD_CHOSEONG_REGEX = new RegExp(
   `[\\u${JASO_HANGUL_NFD.START_CHOSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_CHOSEONG.toString(16)}]`,
   'g'
+);
+const REMOVE_NFD_JUNG_JONG_REGEX = new RegExp(
+  `[\\u${JASO_HANGUL_NFD.START_JUNGSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_JUNGSEONG.toString(16)}\\u${JASO_HANGUL_NFD.START_JONGSEONG.toString(16)}-\\u${JASO_HANGUL_NFD.END_JONGSEONG.toString(16)}]+`,
+  'ug'
 );


### PR DESCRIPTION
## Overview

- 옵션이 true일 때 NFD 중성·종성만 제거하고 숫자·기호 등은 보존
- JSDoc에 옵션 동작과 예시 추가
- 기본 동작 및 신규 동작 단위 테스트 추가

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
