### PR TITLE
fix: allow non-alphabetical characters in convertQwertyToHangul

### DIFF
--- a/.changeset/fix-convert-qwerty-non-alphabet.md
+++ b/.changeset/fix-convert-qwerty-non-alphabet.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": patch
+---
+
+fix: allow non-alphabetical characters in convertQwertyToHangul

--- a/src/keyboard/convertQwertyToHangul/convertQwertyToHangul.spec.ts
+++ b/src/keyboard/convertQwertyToHangul/convertQwertyToHangul.spec.ts
@@ -24,6 +24,12 @@ describe('convertQwertyToHangul', () => {
     expect(convertQwertyToHangul('ㅇPdml')).toBe('예의');
   });
 
+  it('영어가 아닌 문자(숫자, 기호 등)가 포함된 경우 원본 문자를 유지하며 정상 합성한다.', () => {
+    expect(convertQwertyToHangul('slash123')).toBe('님노123');
+    expect(convertQwertyToHangul('dkdlvhs16')).toBe('아이폰16');
+    expect(convertQwertyToHangul('1qkr2dlf')).toBe('1박2일');
+  });
+
   it('빈 문자열은 빈 문자열을 반환한다.', () => {
     expect(convertQwertyToHangul('')).toBe('');
   });

--- a/src/keyboard/convertQwertyToHangul/convertQwertyToHangul.ts
+++ b/src/keyboard/convertQwertyToHangul/convertQwertyToHangul.ts
@@ -4,7 +4,7 @@ import { convertQwertyToAlphabet } from '@/keyboard/convertQwertyToAlphabet';
 /**
  * @name convertQwertyToHangul
  * @description
- * 영어 알파벳을 qwerty 자판과 매칭과는 한글 문자와 문장으로 변환합니다.
+ * 영어 알파벳을 qwerty 자판과 매칭되는 한글 문자와 문장으로 변환합니다.
  * @param word 한글 문장으로 변환하고자 하는 영문
  * @returns qwerty 영어 알파벳을 변환하여 한글 규칙에 맞게 합성한 문자열
  */
@@ -12,5 +12,28 @@ export function convertQwertyToHangul(word: string): string {
   if (!word) {
     return '';
   }
-  return assemble([...convertQwertyToAlphabet(word)]);
+
+  const converted = convertQwertyToAlphabet(word);
+  let result = '';
+  let hangulBuffer: string[] = [];
+
+  const HANGUL_REGEX = /[ㄱ-ㅎㅏ-ㅣ가-힣]/;
+
+  for (const char of converted) {
+    if (HANGUL_REGEX.test(char)) {
+      hangulBuffer.push(char);
+    } else {
+      if (hangulBuffer.length > 0) {
+        result += assemble(hangulBuffer);
+        hangulBuffer = [];
+      }
+      result += char;
+    }
+  }
+
+  if (hangulBuffer.length > 0) {
+    result += assemble(hangulBuffer);
+  }
+
+  return result;
 }

--- a/src/keyboard/convertQwertyToHangul/convertQwertyToHangul.ts
+++ b/src/keyboard/convertQwertyToHangul/convertQwertyToHangul.ts
@@ -1,3 +1,4 @@
+import { isHangulAlphabet, isHangulCharacter } from '@/_internal/hangul';
 import { assemble } from '@/core/assemble';
 import { convertQwertyToAlphabet } from '@/keyboard/convertQwertyToAlphabet';
 
@@ -17,10 +18,8 @@ export function convertQwertyToHangul(word: string): string {
   let result = '';
   let hangulBuffer: string[] = [];
 
-  const HANGUL_REGEX = /[ㄱ-ㅎㅏ-ㅣ가-힣]/;
-
   for (const char of converted) {
-    if (HANGUL_REGEX.test(char)) {
+    if (isHangulAlphabet(char) || isHangulCharacter(char)) {
       hangulBuffer.push(char);
     } else {
       if (hangulBuffer.length > 0) {
@@ -37,3 +36,4 @@ export function convertQwertyToHangul(word: string): string {
 
   return result;
 }
+


### PR DESCRIPTION
Closes #334. This PR updates convertQwertyToHangul to handle non-alphabetical characters (such as numbers, spaces, and special symbols) correctly instead of crashing with an invalid character exception. It achieves this by selectively assembling only valid Hangul blocks.