### PR TITLE
chore: add changeset for getJungseong, getJongseong (#377)

### DIFF
--- a/.changeset/getjungseong-getjongseong.md
+++ b/.changeset/getjungseong-getjongseong.md
@@ -1,0 +1,5 @@
+---
+"es-hangul": minor
+---
+
+feat: 중성을 추출하는 `getJungseong`과 종성을 추출하는 `getJongseong` 함수를 추가합니다. `getChoseong`과 동일하게 존재하는 자모만 추출하고 공백은 유지합니다. (예: `getJungseong('사과')` → `'ㅏㅘ'`, `getJongseong('값')` → `'ㅄ'`)


### PR DESCRIPTION
## Overview

#377 (`getJungseong` / `getJongseong` 추가)이 **changeset 없이 머지**되어, 새 함수가 릴리즈 버전 및 CHANGELOG에 반영되지 않는 상태입니다. 이를 보완하는 changeset을 추가합니다.

- 새 공개 함수 추가이므로 **minor** 버전으로 지정했습니다. (현재 main의 다른 changeset은 `#382`의 patch 하나뿐입니다.)
- 이 PR이 머지되면 changesets가 두 함수 추가를 minor 버전으로 묶어 릴리즈합니다.

관련: #377, #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)