### PR TITLE
fix(ci): release 워크플로우에 pull-requests 쓰기 권한 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Overview

릴리즈 워크플로우가 changeset을 소비해 버전 범프까지 수행하지만, **"chore: version packages" 릴리즈 PR을 생성하는 단계에서 실패**하고 있었습니다.

```
HttpError: Resource not accessible by integration - create-a-pull-request
```

## 원인

`changesets/action`이 릴리즈 PR을 생성하려면 `pull-requests: write` 권한이 필요합니다. 하지만 워크플로우의 `permissions:` 블록에 `id-token`과 `contents`만 명시되어 있어, (명시 블록이 있으면 나열된 권한만 부여되므로) `pull-requests` 권한이 없어 PR 생성이 거부되었습니다.

저장소 설정(Settings → Actions)의 "Allow GitHub Actions to create and approve pull requests"는 이미 켜져 있어, 워크플로우 권한만 보완하면 됩니다.

## 수정

`permissions`에 `pull-requests: write`를 추가합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)