### PR TITLE
test: document non-Hangul canBe cases

### DIFF
--- a/src/core/canBeChoseong/canBeChoseong.spec.ts
+++ b/src/core/canBeChoseong/canBeChoseong.spec.ts
@@ -23,5 +23,13 @@ describe('canBeChoseong', () => {
     it('가', () => {
       expect(canBeChoseong('가')).toBe(false);
     });
+    it.each([
+      { category: '영어', character: 'A' },
+      { category: '빈칸', character: ' ' },
+      { category: '다른 언어', character: 'あ' },
+      { category: '특수문자', character: '!' },
+    ])('$category 문자', ({ character }) => {
+      expect(canBeChoseong(character)).toBe(false);
+    });
   });
 });

--- a/src/core/canBeJongseong/canBeJongseong.spec.ts
+++ b/src/core/canBeJongseong/canBeJongseong.spec.ts
@@ -26,5 +26,13 @@ describe('canBeJongseong', () => {
     it('가', () => {
       expect(canBeJongseong('ㅏ')).toBe(false);
     });
+    it.each([
+      { category: '영어', character: 'A' },
+      { category: '빈칸', character: ' ' },
+      { category: '다른 언어', character: 'あ' },
+      { category: '특수문자', character: '!' },
+    ])('$category 문자', ({ character }) => {
+      expect(canBeJongseong(character)).toBe(false);
+    });
   });
 });

--- a/src/core/canBeJungseong/canBeJungseong.spec.ts
+++ b/src/core/canBeJungseong/canBeJungseong.spec.ts
@@ -23,5 +23,13 @@ describe('canBeJungseong', () => {
     it('가', () => {
       expect(canBeJungseong('가')).toBe(false);
     });
+    it.each([
+      { category: '영어', character: 'A' },
+      { category: '빈칸', character: ' ' },
+      { category: '다른 언어', character: 'あ' },
+      { category: '특수문자', character: '!' },
+    ])('$category 문자', ({ character }) => {
+      expect(canBeJungseong(character)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Overview

Adds explicit English, blank, other-language, and special-character cases to the three `canBe*` specs. This makes the predicates' non-Hangul behavior visible directly in their tests.

Closes #194

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.

## Verification

- `yarn test` (38 files, 414 tests)
- `yarn typecheck`
- `yarn build`
- `yarn publint`
- `yarn attw`
- Prettier check for the changed specs
