### PR TITLE
refactor: 역방향 객체 생성 로직을 공통 invert 유틸로 분리하고 combineVowels·getJongseong에 적용

### DIFF
--- a/src/_internal/index.ts
+++ b/src/_internal/index.ts
@@ -38,3 +38,17 @@ export function hasValueInReadOnlyStringList<T extends string>(list: readonly T[
 export function hasProperty<T extends object, K extends PropertyKey>(obj: T, key: K): key is K & keyof T {
   return Object.prototype.hasOwnProperty.call(obj, key);
 }
+
+export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record<K, V>): Record<V, K> {
+  const result = {} as Record<V, K>;
+
+  const keys = Object.keys(obj) as K[];
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = obj[key];
+    result[value] = key;
+  }
+
+  return result;
+}

--- a/src/core/combineVowels/combineVowels.ts
+++ b/src/core/combineVowels/combineVowels.ts
@@ -1,3 +1,4 @@
+import { invert } from '@/_internal';
 import { DISASSEMBLED_VOWELS_BY_VOWEL } from '@/_internal/constants';
 
 /**
@@ -21,7 +22,9 @@ import { DISASSEMBLED_VOWELS_BY_VOWEL } from '@/_internal/constants';
 type Invert<T extends Record<string, string>> = { [K in keyof T as T[K]]: K };
 type CombineVowel = Invert<typeof DISASSEMBLED_VOWELS_BY_VOWEL>;
 
+const VOWEL_BY_DISASSEMBLED_VOWELS = invert(DISASSEMBLED_VOWELS_BY_VOWEL);
+
 export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
-  return (Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(([, value]) => value === `${vowel1}${vowel2}`)?.[0] ??
+  return (VOWEL_BY_DISASSEMBLED_VOWELS[`${vowel1}${vowel2}` as keyof CombineVowel] ??
     `${vowel1}${vowel2}`) as `${V1}${V2}` extends keyof CombineVowel ? CombineVowel[`${V1}${V2}`] : `${V1}${V2}`;
 }

--- a/src/core/getJongseong/getJongseong.ts
+++ b/src/core/getJongseong/getJongseong.ts
@@ -1,5 +1,6 @@
 import { DISASSEMBLED_CONSONANTS_BY_CONSONANT, JONGSEONGS } from '@/_internal/constants';
 import { JASO_HANGUL_NFD } from '../getChoseong/constants';
+import { invert } from '@/_internal';
 
 /**
  * @name getJongseong
@@ -35,9 +36,7 @@ const CHOOSE_NFD_JONGSEONG_REGEX = new RegExp(
   'g'
 );
 
-const CONSONANT_BY_DISASSEMBLED_CONSONANT = Object.fromEntries(
-  Object.entries(DISASSEMBLED_CONSONANTS_BY_CONSONANT).map(([key, val]) => [val, key])
-);
+const CONSONANT_BY_DISASSEMBLED_CONSONANT = invert(DISASSEMBLED_CONSONANTS_BY_CONSONANT);
 
 const JONGSEONGS_COMPOSITE = JONGSEONGS.slice(1).map(d => CONSONANT_BY_DISASSEMBLED_CONSONANT[d]);
 

--- a/src/core/getJongseong/getJongseong.ts
+++ b/src/core/getJongseong/getJongseong.ts
@@ -35,9 +35,9 @@ const CHOOSE_NFD_JONGSEONG_REGEX = new RegExp(
   'g'
 );
 
-const JONGSEONGS_COMPOSITE = JONGSEONGS.slice(1).map(
-  d => Object.fromEntries(
-    Object.entries(DISASSEMBLED_CONSONANTS_BY_CONSONANT).map(([key, val]) => [val, key])
-  )[d]
+const CONSONANT_BY_DISASSEMBLED_CONSONANT = Object.fromEntries(
+  Object.entries(DISASSEMBLED_CONSONANTS_BY_CONSONANT).map(([key, val]) => [val, key])
 );
+
+const JONGSEONGS_COMPOSITE = JONGSEONGS.slice(1).map(d => CONSONANT_BY_DISASSEMBLED_CONSONANT[d]);
 


### PR DESCRIPTION
## Overview

역방향 조회용 객체를 만드는 로직이 각 함수에 흩어져 있고, 일부는 호출·순회마다 역방향 객체를 새로 생성하는 비효율인 부분이 있었습니다.
공통 `invert` 유틸을 추가해 역방향 객체 생성을 일원화하고, `combineVowels`와 `getJongseong`이 이를 사용하도록 리팩터링했습니다.

## 문제 상황 (as-is)

**1. `combineVowels` — 호출마다 O(n) 선형 탐색**

```ts
export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
  return (Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(([, value]) => value === `${vowel1}${vowel2}`)?.[0] ??
    `${vowel1}${vowel2}`) as ...;
}
```

- 함수를 호출할 때마다 `Object.entries(...).find(...)`로 역방향 탐색을 선형(O(n))으로 수행합니다.

**2. `getJongseong` — 역방향 객체를 매 순회마다 재생성**

```ts
const JONGSEONGS_COMPOSITE = JONGSEONGS.slice(1).map(
  d => Object.fromEntries(
    Object.entries(DISASSEMBLED_CONSONANTS_BY_CONSONANT).map(([key, val]) => [val, key])
  )[d]
);
```

- `Object.fromEntries(...)`로 만드는 역방향 객체가 `.map` 콜백이 실행될 때마다 **매번 새로 생성**됩니다.
- `JONGSEONGS.slice(1)`의 길이만큼 동일한 객체를 반복 생성합니다. → 사실상 `O(n²)`

## 변경 사항 (to-be)

### 1. 공통 `invert` 유틸 추가 (`src/_internal`)
공통 `invert` 유틸을 추가해 역방향 객체 생성을 일원화하고, `combineVowels`와 `getJongseong`이 이를 사용하도록 리팩터링했습니다.
- invert의 경우 es-toolkit의 로직을 가져왔습니다.
- https://github.com/toss/es-toolkit/blob/main/src/object/invert.ts

```ts
export function invert<K extends PropertyKey, V extends PropertyKey>(obj: Record<K, V>): Record<V, K> {
  const result = {} as Record<V, K>;
  const keys = Object.keys(obj) as K[];

  for (let i = 0; i < keys.length; i++) {
    const key = keys[i];
    const value = obj[key];
    result[value] = key;
  }

  return result;
}
```

### 2. `combineVowels` 적용

호출마다 `entries`를 생성하고,`find`로 탐색하던 로직을, 모듈 스코프에서 `invert`로 1회 생성한 역방향 객체를 통해 조회(`O(1)`)하도록 변경했습니다.

```ts
const VOWEL_BY_DISASSEMBLED_VOWELS = invert(DISASSEMBLED_VOWELS_BY_VOWEL);

export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
  return (VOWEL_BY_DISASSEMBLED_VOWELS[`${vowel1}${vowel2}` as keyof CombineVowel] ??
    `${vowel1}${vowel2}`) as `${V1}${V2}` extends keyof CombineVowel ? CombineVowel[`${V1}${V2}`] : `${V1}${V2}`;
}
```

### 3. `getJongseong` 적용

동일하게 역방향 객체를 모듈 스코프에서 한 번만 생성하도록 분리합니다.

```ts
const CONSONANT_BY_DISASSEMBLED_CONSONANT = invert(DISASSEMBLED_CONSONANTS_BY_CONSONANT);

const JONGSEONGS_COMPOSITE = JONGSEONGS.slice(1).map(d => CONSONANT_BY_DISASSEMBLED_CONSONANT[d]);
```

### 개선 포인트

- 역방향 객체 생성 로직을 `invert` 유틸로 일원화 (중복 제거, 재사용성 확보)
- `combineVowels`: 호출마다 `entries` 생성 후 `find` 탐색 → 모듈 스코프에서 역방향 객체 생성 후 `O(1)` 객체 조회로 개선
- `getJongseong`: JONGSEONGS.slice(1)`의 길이만큼(약 27회) 동일한 객체를 반복 생성하는 것을 사전 생성 후 조회로 개선

## 영향도

- `combineVowels`, `getJongseong`의 동작은 동일하며, 기존 테스트는 모두 통과합니다.
- 내부 구현만 개선한 리팩터링입니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.

