### PR TITLE
refactor(combineVowels): Object.entries+find 선형 탐색을 사전 생성 역맵 조회로 대체

### DIFF
--- a/src/core/combineVowels/combineVowels.ts
+++ b/src/core/combineVowels/combineVowels.ts
@@ -21,7 +21,15 @@ import { DISASSEMBLED_VOWELS_BY_VOWEL } from '@/_internal/constants';
 type Invert<T extends Record<string, string>> = { [K in keyof T as T[K]]: K };
 type CombineVowel = Invert<typeof DISASSEMBLED_VOWELS_BY_VOWEL>;
 
+const VOWEL_BY_DISASSEMBLED_VOWELS = Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).reduce<Record<string, string>>(
+  (acc, [vowel, disassembled]) => {
+    acc[disassembled] = vowel;
+    return acc;
+  },
+  {}
+);
+
 export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
-  return (Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(([, value]) => value === `${vowel1}${vowel2}`)?.[0] ??
+  return (VOWEL_BY_DISASSEMBLED_VOWELS[`${vowel1}${vowel2}`] ??
     `${vowel1}${vowel2}`) as `${V1}${V2}` extends keyof CombineVowel ? CombineVowel[`${V1}${V2}`] : `${V1}${V2}`;
 }


### PR DESCRIPTION
## Overview

`combineVowels` 함수가 호출될 때마다 `Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(...)`로 역방향(분해된 모음 → 모음) 탐색을 선형(O(n))으로 수행하고 있습니다.

이를 개선하기 위해 모듈 스코프에서 `{ 분해된 모음 → 모음 }` 역맵(`VOWEL_BY_DISASSEMBLED_VOWELS`)을 **한 번만** 생성하고, 함수 내부에서는 O(1) 직접 조회로 값을 얻도록 개선합니다.

## 문제 상황 (as-is)

```ts
export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
  return (Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).find(([, value]) => value === `${vowel1}${vowel2}`)?.[0] ??
    `${vowel1}${vowel2}`) as `${V1}${V2}` extends keyof CombineVowel ? CombineVowel[`${V1}${V2}`] : `${V1}${V2}`;
}
```

- combineVowels 호출 시 매번 entries를 생성하고, find를 호출

<br />

## 변경 사항 (to-be)

```ts
const VOWEL_BY_DISASSEMBLED_VOWELS = Object.entries(DISASSEMBLED_VOWELS_BY_VOWEL).reduce<Record<string, string>>(
  (acc, [vowel, disassembled]) => {
    acc[disassembled] = vowel;
    return acc;
  },
  {}
);

export function combineVowels<V1 extends string, V2 extends string>(vowel1: V1, vowel2: V2) {
  return (VOWEL_BY_DISASSEMBLED_VOWELS[`${vowel1}${vowel2}`] ??
    `${vowel1}${vowel2}`) as `${V1}${V2}` extends keyof CombineVowel ? CombineVowel[`${V1}${V2}`] : `${V1}${V2}`;
}
```

- 모듈 로드 시 `DISASSEMBLED_VOWELS_BY_VOWEL`을 순회하여 역맵을 1회 생성
- 함수 호출부는 매번 `find` 하던 것을 역맵 인덱싱(`O(1)`)으로 대체

## 영향도

- `combineVowels`의 최종 값은 동일하며, 테스트도 동일하게 통과합니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.

