### PR TITLE
test: getChoseong, disassemble에 비한글 문자 경계 케이스 테스트 추가

### DIFF
--- a/src/core/disassemble/disassemble.spec.ts
+++ b/src/core/disassemble/disassemble.spec.ts
@@ -20,4 +20,28 @@ describe('disassemble', () => {
   it('ㅘ', () => {
     expect(disassemble('ㅘ')).toEqual('ㅗㅏ');
   });
+
+  describe('한글이 아닌 문자 처리', () => {
+    it('영어는 분해하지 않고 그대로 유지한다.', () => {
+      expect(disassemble('abc')).toEqual('abc');
+      expect(disassemble('값abc')).toEqual('ㄱㅏㅂㅅabc');
+    });
+
+    it('특수문자는 그대로 유지한다.', () => {
+      expect(disassemble('값!@#')).toEqual('ㄱㅏㅂㅅ!@#');
+    });
+
+    it('한글이 아닌 다른 언어는 그대로 유지한다.', () => {
+      expect(disassemble('りんご')).toEqual('りんご');
+      expect(disassemble('中國')).toEqual('中國');
+    });
+
+    it('숫자는 그대로 유지한다.', () => {
+      expect(disassemble('값123')).toEqual('ㄱㅏㅂㅅ123');
+    });
+
+    it('빈 문자열은 빈 문자열을 반환한다.', () => {
+      expect(disassemble('')).toEqual('');
+    });
+  });
 });

--- a/src/core/getChoseong/getChoseong.spec.ts
+++ b/src/core/getChoseong/getChoseong.spec.ts
@@ -25,4 +25,29 @@ describe('getChoseong', () => {
   it('keepNonHangul이 true이면 숫자 등 비한글을 유지한다.', () => {
     expect(getChoseong('네이버123', { keepNonHangul: true })).toBe('ㄴㅇㅂ123');
   });
+
+  describe('한글이 아닌 문자 처리', () => {
+    it('영어는 제거한다.', () => {
+      expect(getChoseong('apple')).toBe('');
+      expect(getChoseong('사과apple')).toBe('ㅅㄱ');
+    });
+
+    it('특수문자는 제거한다.', () => {
+      expect(getChoseong('사과!@#')).toBe('ㅅㄱ');
+    });
+
+    it('한글이 아닌 다른 언어는 제거한다.', () => {
+      expect(getChoseong('りんご')).toBe('');
+      expect(getChoseong('中國')).toBe('');
+    });
+
+    it('빈 문자열은 빈 문자열을 반환한다.', () => {
+      expect(getChoseong('')).toBe('');
+    });
+
+    it('keepNonHangul이 true이면 영어와 특수문자를 유지한다.', () => {
+      expect(getChoseong('사과apple', { keepNonHangul: true })).toBe('ㅅㄱapple');
+      expect(getChoseong('사과!@#', { keepNonHangul: true })).toBe('ㅅㄱ!@#');
+    });
+  });
 });


### PR DESCRIPTION
## Overview

#194 관련 작업입니다. core 모듈의 `getChoseong`, `disassemble`에 영어, 빈 문자열, 다른 언어, 특수문자 경계 케이스 테스트를 추가했습니다. (#390에서 진행 중인 `canBe*` 함수들과 겹치지 않는 함수를 골랐습니다.)

- `getChoseong`: 비한글 문자를 제거 (공백은 유지)
- `disassemble`: 비한글 문자를 그대로 유지

## 질문

`keepNonHangul: true`일 때 한글이 아닌 문자가 NFD로 분해된 채 반환되는데, 의도된 동작인건가요?

```ts
getChoseong('café', { keepNonHangul: true }) === 'café'; // false — é가 e + U+0301로 분해됨
getChoseong('りんご', { keepNonHangul: true }) === 'りんご'; // false — ご가 こ + U+3099로 분해됨
```

내부의 `normalize('NFD')` 이후에 비한글 문자가 NFC로 복원되지 않아서 생기는 현상 같습니다.
문서에는 "한글 외 문자를 그대로 둡니다"라고 되어 있어서 질문드립니다.
버그가 맞다면 별도 이슈로 분리하겠습니다. (이 동작은 테스트로 고정하지 않았습니다.)

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
