### PR TITLE
test: getJungseong, getJongseong 등 9개 함수에 비한글 문자 경계 케이스 테스트 추가

### DIFF
--- a/src/core/assemble/assemble.spec.ts
+++ b/src/core/assemble/assemble.spec.ts
@@ -17,4 +17,10 @@ describe('assemble', () => {
     expect(assemble(['ㄱ', 'ㅏ', '!', 'ㄴ', 'ㅏ'])).toEqual('가!나');
     expect(assemble(['ㅇ', 'ㅑ', '1', 'ㅎ', 'ㅏ'])).toEqual('야1하');
   });
+
+  it('영어나 한글이 아닌 다른 언어도 조합하지 않고 그대로 유지한다', () => {
+    expect(assemble(['a', 'b'])).toEqual('ab');
+    expect(assemble(['ㄱ', 'a'])).toEqual('ㄱa');
+    expect(assemble(['안', 'あ'])).toEqual('안あ');
+  });
 });

--- a/src/core/combineCharacter/combineCharacter.spec.ts
+++ b/src/core/combineCharacter/combineCharacter.spec.ts
@@ -28,4 +28,11 @@ describe('combineCharacter', () => {
   it('온전한 한글 문자가 하나라도 입력되면 에러를 반환한다. (가, ㅏ, ㄱ)', () => {
     expect(() => combineCharacter('가', 'ㅏ', 'ㄱ')).toThrowError('Invalid hangul Characters: 가, ㅏ, ㄱ');
   });
+
+  it('영어, 특수문자, 빈 문자열 등 한글이 아닌 문자가 입력되면 에러를 반환한다.', () => {
+    expect(() => combineCharacter('a', 'ㅏ')).toThrowError('Invalid hangul Characters: a, ㅏ, ');
+    expect(() => combineCharacter('ㄱ', 'a')).toThrowError('Invalid hangul Characters: ㄱ, a, ');
+    expect(() => combineCharacter('ㄱ', 'ㅏ', '!')).toThrowError('Invalid hangul Characters: ㄱ, ㅏ, !');
+    expect(() => combineCharacter('', '')).toThrowError('Invalid hangul Characters: , , ');
+  });
 });

--- a/src/core/combineVowels/combineVowels.spec.ts
+++ b/src/core/combineVowels/combineVowels.spec.ts
@@ -14,4 +14,13 @@ describe('combineVowels', () => {
     expect(combineVowels('ㅘ', 'ㅏ')).toBe('ㅘㅏ');
     expect(combineVowels('ㅝ', 'ㅣ')).toBe('ㅝㅣ');
   });
+
+  it('영어 등 모음이 아닌 문자가 입력되면 Join한다.', () => {
+    expect(combineVowels('a', 'b')).toBe('ab');
+    expect(combineVowels('ㅗ', 'a')).toBe('ㅗa');
+  });
+
+  it('빈 문자열이 입력되면 빈 문자열을 반환한다.', () => {
+    expect(combineVowels('', '')).toBe('');
+  });
 });

--- a/src/core/disassembleCompleteCharacter/disassembleCompleteCharacter.spec.ts
+++ b/src/core/disassembleCompleteCharacter/disassembleCompleteCharacter.spec.ts
@@ -37,4 +37,11 @@ describe('disassembleCompleteCharacter', () => {
     expect(disassembleCompleteCharacter('ㄱ')).toBeUndefined();
     expect(disassembleCompleteCharacter('ㅏ')).toBeUndefined();
   });
+
+  it('영어, 특수문자, 다른 언어, 빈 문자열도 undefined를 반환해야 합니다.', () => {
+    expect(disassembleCompleteCharacter('a')).toBeUndefined();
+    expect(disassembleCompleteCharacter('!')).toBeUndefined();
+    expect(disassembleCompleteCharacter('あ')).toBeUndefined();
+    expect(disassembleCompleteCharacter('')).toBeUndefined();
+  });
 });

--- a/src/core/disassembleToGroups/disassembleToGroups.spec.ts
+++ b/src/core/disassembleToGroups/disassembleToGroups.spec.ts
@@ -27,4 +27,19 @@ describe('disassembleToGroups', () => {
   it('ㅘ', () => {
     expect(disassembleToGroups('ㅘ')).toEqual([['ㅗ', 'ㅏ']]);
   });
+
+  describe('한글이 아닌 문자 처리', () => {
+    it('영어는 분해하지 않고 한 글자씩 그룹으로 유지한다.', () => {
+      expect(disassembleToGroups('값abc')).toEqual([['ㄱ', 'ㅏ', 'ㅂ', 'ㅅ'], ['a'], ['b'], ['c']]);
+    });
+
+    it('특수문자와 한글이 아닌 다른 언어는 그대로 유지한다.', () => {
+      expect(disassembleToGroups('a!')).toEqual([['a'], ['!']]);
+      expect(disassembleToGroups('あ')).toEqual([['あ']]);
+    });
+
+    it('빈 문자열은 빈 배열을 반환한다.', () => {
+      expect(disassembleToGroups('')).toEqual([]);
+    });
+  });
 });

--- a/src/core/getJongseong/getJongseong.spec.ts
+++ b/src/core/getJongseong/getJongseong.spec.ts
@@ -22,6 +22,25 @@ describe('getJongseong', () => {
   it('"파이팅" 단어에서 종성 "ㅇ"을 추출한다.', () => {
     expect(getJongseong('파이팅')).toBe('ㅇ');
   });
+
+  describe('한글이 아닌 문자 처리', () => {
+    it('영어는 제거한다.', () => {
+      expect(getJongseong('apple')).toBe('');
+      expect(getJongseong('강산apple')).toBe('ㅇㄴ');
+    });
+
+    it('특수문자는 제거한다.', () => {
+      expect(getJongseong('강산!@#')).toBe('ㅇㄴ');
+    });
+
+    it('공백은 유지한다.', () => {
+      expect(getJongseong('강산 물')).toBe('ㅇㄴ ㄹ');
+    });
+
+    it('빈 문자열은 빈 문자열을 반환한다.', () => {
+      expect(getJongseong('')).toBe('');
+    });
+  });
 });
 
 

--- a/src/core/getJungseong/getJungseong.spec.ts
+++ b/src/core/getJungseong/getJungseong.spec.ts
@@ -17,6 +17,29 @@ describe('getJungseong', () => {
   it('"띄어 쓰기" 문장에서 중성 "ㅢㅓ ㅡㅣ"을 추출한다.', () => {
     expect(getJungseong('띄어 쓰기')).toBe('ㅢㅓ ㅡㅣ');
   });
+
+  describe('한글이 아닌 문자 처리', () => {
+    it('영어는 제거한다.', () => {
+      expect(getJungseong('apple')).toBe('');
+      expect(getJungseong('사과apple')).toBe('ㅏㅘ');
+    });
+
+    it('특수문자는 제거한다.', () => {
+      expect(getJungseong('사과!@#')).toBe('ㅏㅘ');
+    });
+
+    it('한글이 아닌 다른 언어는 제거한다.', () => {
+      expect(getJungseong('りんご')).toBe('');
+    });
+
+    it('공백은 유지한다.', () => {
+      expect(getJungseong('사과 배')).toBe('ㅏㅘ ㅐ');
+    });
+
+    it('빈 문자열은 빈 문자열을 반환한다.', () => {
+      expect(getJungseong('')).toBe('');
+    });
+  });
 });
 
 

--- a/src/number/amountToHangul/amountToHangul.spec.ts
+++ b/src/number/amountToHangul/amountToHangul.spec.ts
@@ -16,6 +16,12 @@ describe('amountToHangul', () => {
 
   it('숫자 외 문자를 무시하여 반환', () => {
     expect(amountToHangul('120,030원')).toEqual('일십이만삼십');
+    expect(amountToHangul('123abc')).toEqual('일백이십삼');
+    expect(amountToHangul('12!@#')).toEqual('일십이');
+  });
+
+  it('숫자가 없는 문자열은 빈 문자열을 반환', () => {
+    expect(amountToHangul('abc')).toEqual('');
   });
 
   it('소수점이 있는 경우도 표기', () => {

--- a/src/pronunciation/romanize/romanize.spec.ts
+++ b/src/pronunciation/romanize/romanize.spec.ts
@@ -80,4 +80,8 @@ describe('romanize', () => {
     expect(romanize('한국은korea')).toBe('hangugeunkorea');
     expect(romanize('고양이는cat')).toBe('goyangineuncat');
   });
+
+  it('한글이 아닌 다른 언어는 그대로 반환된다', () => {
+    expect(romanize('안녕あ')).toBe('annyeongあ');
+  });
 });


### PR DESCRIPTION
## Overview

#194 관련 두 번째 작업입니다. #393(getChoseong, disassemble)에 이어서, 아직 경계 케이스 테스트가 없는 9개 함수에 영어, 빈 문자열, 다른 언어, 특수문자 케이스를 추가했습니다.

- `getJungseong`, `getJongseong`: 비한글 제거 (공백은 유지)
- `disassembleToGroups`, `assemble`, `romanize`: 비한글 그대로 유지
- `disassembleCompleteCharacter`: 비한글 입력 시 `undefined`
- `combineCharacter`: 비한글 입력 시 에러
- `combineVowels`: 모음이 아닌 입력은 Join
- `amountToHangul`: 숫자 외 문자 무시

다음 함수들은 제외했습니다.

- `canBe*` 3개: #390에서 진행 중으로 보여서 테스트 범위에서 뺐습니다.
- `hasBatchim`, `standardizePronunciation`: 이미 비한글 케이스가 충분하다고 판단되어 테스트 범위에서 뺐습니다.
- `josa`: 특수문자로 끝나는 단어의 조사 선택 기준이 설계 논의가 필요해 보여서 테스트 범위에서 뺐습니다.
- `susa`, `seosusa`, `days`, `numberToHangul`, `numberToHangulMixed`: 숫자만 받는 함수라 불필요하다고 판단되어 테스트 범위에서 뺐습니다.

## 질문

`assemble`에 빈 배열을 넣으면 처리되지 않은 TypeError가 발생합니다.

```ts
assemble([]); // TypeError: Reduce of empty array with no initial value
```

빈 문자열을 반환하는 게 자연스러워 보인다고 생각합니다.
의도된 동작이 아니라면 별도 이슈로 분리하겠습니다.

## PR Checklist

- [x] I read and included theses actions below

1. I have read the [Contributing Guide](https://github.com/toss/es-hangul/blob/main/.github/CONTRIBUTING.md)
2. I have written documents and tests, if needed.
